### PR TITLE
Add redstone and farming categories to shop config

### DIFF
--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -135,7 +135,15 @@ categories:
     EMERALD: { buy: 100.0, sell: 50.0 }
     EMERALD_BLOCK: { buy: 900.0, sell: 450.0 }
     LAPIS_LAZULI: { buy: 8.0, sell: 4.0 }
-    REDSTONE: { buy: 4.0, sell: 2.0 }
     REDSTONE_BLOCK: { buy: 36.0, sell: 18.0 }
     GLOWSTONE_DUST: { buy: 4.0, sell: 2.0 }
     QUARTZ: { buy: 10.0, sell: 5.0 }
+  redstone:
+    REDSTONE: { buy: 4.0, sell: 2.0 }
+    REDSTONE_TORCH: { buy: 8.0, sell: 4.0 }
+    REPEATER: { buy: 20.0, sell: 10.0 }
+    COMPARATOR: { buy: 30.0, sell: 15.0 }
+  farming:
+    WHEAT_SEEDS: { buy: 1.0, sell: 0.5 }
+    CARROT: { buy: 2.0, sell: 1.0 }
+    POTATO: { buy: 2.0, sell: 1.0 }


### PR DESCRIPTION
## Summary
- add new redstone category with dust, torch, repeater and comparator
- add farming category for seeds, carrots, and potatoes

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a10dcd727c832ebcf7c1273c353050