### PR TITLE
Adjust dynamic pricing on bulk sells

### DIFF
--- a/src/main/java/com/yourorg/servershop/gui/SellMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/SellMenu.java
@@ -62,8 +62,8 @@ public final class SellMenu implements MenuView {
             double amount = unit * qty;
             total += amount; stacks++;
             p.getInventory().setItem(i, null);
+            plugin.dynamic().adjustOnSell(m, qty);
             plugin.logger().logAsync(new com.yourorg.servershop.logging.Transaction(java.time.Instant.now(), p.getName(), com.yourorg.servershop.logging.Transaction.Type.SELL, m, qty, amount));
-            // TODO: consider calling plugin.dynamic().adjustOnSell(m, qty) per TODO list
         }
         if (total > 0) plugin.economy().depositPlayer(p, total);
         p.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.soldall").replace("%count%", String.valueOf(stacks)).replace("%total%", String.format("%.2f", total))));


### PR DESCRIPTION
## Summary
- Apply dynamic pricing adjustments when selling all items via GUI
- Leverage existing per-item pricing manager with YAML/MySQL storage, decay toward 1 and clamping

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a10ffbd454832ebeb0868787239c0b