### PR TITLE
Add runtime category reload

### DIFF
--- a/src/main/java/com/yourorg/servershop/commands/AdminCommand.java
+++ b/src/main/java/com/yourorg/servershop/commands/AdminCommand.java
@@ -17,7 +17,12 @@ public final class AdminCommand {
         switch (args[1].toLowerCase()) {
             case "category": return handleCategory(sender, slice(args, 2));
             case "import": return handleImport(sender);
-            case "reload": plugin.reloadConfig(); plugin.catalog().reload(); sender.sendMessage(plugin.prefixed("Reloaded.")); return true;
+            case "reload":
+                plugin.reloadConfig();
+                plugin.categorySettings().load();
+                plugin.catalog().reload();
+                sender.sendMessage(plugin.prefixed("Reloaded."));
+                return true;
             default: help(sender); return true;
         }
     }
@@ -65,10 +70,15 @@ public final class AdminCommand {
             sender.sendMessage(plugin.prefixed("Category "+cat+" is now "+(on?"enabled":"disabled")));
             return true;
         }
+        if (sub.equals("reload")) {
+            plugin.categorySettings().load();
+            sender.sendMessage(plugin.prefixed("Categories reloaded."));
+            return true;
+        }
         helpCategory(sender); return true;
     }
 
     private static String[] slice(String[] a, int from) { String[] b = new String[Math.max(0, a.length-from)]; System.arraycopy(a, from, b, 0, b.length); return b; }
-    private void help(CommandSender s) { s.sendMessage(plugin.prefixed("/shop admin category <list|setmult|toggle> ... | import | reload")); }
-    private void helpCategory(CommandSender s) { s.sendMessage(plugin.prefixed("/shop admin category list | setmult <cat> <x> | toggle <cat> <on|off>")); }
+    private void help(CommandSender s) { s.sendMessage(plugin.prefixed("/shop admin category <list|setmult|toggle|reload> ... | import | reload")); }
+    private void helpCategory(CommandSender s) { s.sendMessage(plugin.prefixed("/shop admin category list | setmult <cat> <x> | toggle <cat> <on|off> | reload")); }
 }

--- a/src/main/java/com/yourorg/servershop/commands/ShopCommand.java
+++ b/src/main/java/com/yourorg/servershop/commands/ShopCommand.java
@@ -88,7 +88,7 @@ public final class ShopCommand implements TabExecutor {
         if (args[0].equalsIgnoreCase("admin")) {
             if (args.length == 2) { suggest(out, args[1], "category","import","reload"); return out; }
             if (args[1].equalsIgnoreCase("category")) {
-                if (args.length == 3) { suggest(out, args[2], "list","setmult","toggle"); return out; }
+                if (args.length == 3) { suggest(out, args[2], "list","setmult","toggle","reload"); return out; }
                 if (args[2].equalsIgnoreCase("setmult")) {
                     if (args.length == 4) { suggestCats(out, args[3]); return out; }
                     if (args.length == 5) { suggest(out, args[4], "0.5","0.75","1","1.25","1.5"); return out; }
@@ -97,6 +97,7 @@ public final class ShopCommand implements TabExecutor {
                     if (args.length == 4) { suggestCats(out, args[3]); return out; }
                     if (args.length == 5) { suggest(out, args[4], "on","off"); return out; }
                 }
+                if (args[2].equalsIgnoreCase("reload")) { return out; }
             }
             return out;
         }


### PR DESCRIPTION
## Summary
- allow `/shop admin reload` to reload category settings
- add `/shop admin category reload` subcommand and tab completion

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a10ffefbbc832e8e3f88f72198cc61