### PR TITLE
Exclude books and horse armor from shop import

### DIFF
--- a/src/main/java/com/yourorg/servershop/importer/ShopImporter.java
+++ b/src/main/java/com/yourorg/servershop/importer/ShopImporter.java
@@ -14,7 +14,7 @@ public final class ShopImporter {
 
     private static final List<String> DISALLOWED = List.of(
             "SWORD","AXE","PICKAXE","SHOVEL","HOE","SHEARS","FISHING_ROD","FLINT_AND_STEEL",
-            "HELMET","CHESTPLATE","LEGGINGS","BOOTS","SHIELD","ELYTRA",
+            "HELMET","CHESTPLATE","LEGGINGS","BOOTS","SHIELD","ELYTRA","HORSE_ARMOR",
             "BOW","CROSSBOW","TRIDENT",
             "POTION","SPLASH_POTION","LINGERING_POTION","TIPPED_ARROW",
             "ARROW","SPECTRAL_ARROW",
@@ -36,6 +36,7 @@ public final class ShopImporter {
 
     private static boolean disallowed(Material m) {
         String u = m.name();
+        if (u.contains("BOOK") && !u.equals("BOOKSHELF")) return true;
         for (String s : DISALLOWED) if (u.contains(s)) return true;
         for (String s : FOOD) if (u.equals(s) || u.endsWith("_"+s) || u.contains(s)) return true;
         return false;


### PR DESCRIPTION
## Summary
- extend shop importer to omit horse armor
- filter out book items except bookshelves

## Testing
- `mvn -q test` *(fails: plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1100f5a7c832ea081c3ada1471646