### PR TITLE
Add time index for MySQL log storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # ShopMC
 MC Shop
+
+## Logging
+
+This plugin records shop transactions either to a local YAML file or to a
+MySQL database. Logging and lookups run asynchronously to avoid blocking the
+server thread. When using MySQL, the table is created with indexes on the
+player and timestamp columns to keep queries fast.

--- a/src/main/java/com/yourorg/servershop/logging/SQLLogStorage.java
+++ b/src/main/java/com/yourorg/servershop/logging/SQLLogStorage.java
@@ -33,6 +33,8 @@ public final class SQLLogStorage implements LogStorage {
                     "amount DOUBLE NOT NULL," +
                     "INDEX idx_player_time (player, time_ms)" +
                     ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            // Ensure efficient global queries by indexing by time as well
+            st.executeUpdate("CREATE INDEX IF NOT EXISTS idx_time_ms ON servershop_transactions(time_ms)");
         }
     }
 


### PR DESCRIPTION
## Summary
- Document asynchronous YAML/MySQL transaction logging
- Ensure MySQL log table has an index on timestamp for faster global queries

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a11013dd4c832eaa43a4499a93ef45