### PR TITLE
Configure POM for Vault via JitPack and UTF-8 compiler encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
   </properties>
 
   <repositories>
@@ -24,8 +25,8 @@
       <url>https://oss.sonatype.org/content/groups/public/</url>
     </repository>
     <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io/</url>
+      <id>jitpack</id>
+      <url>https://jitpack.io</url>
     </repository>
   </repositories>
 
@@ -62,7 +63,7 @@
         <version>3.11.0</version>
         <configuration>
           <release>17</release>
-          <encoding>UTF-8</encoding>
+          <encoding>${maven.compiler.encoding}</encoding>
         </configuration>
       </plugin>
       <plugin>
@@ -75,6 +76,7 @@
             <goals><goal>shade</goal></goals>
             <configuration>
               <minimizeJar>false</minimizeJar>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <relocations/>
             </configuration>
           </execution>


### PR DESCRIPTION
## Summary
- Ensure JitPack repository is used to resolve Vault API
- Use UTF-8 as the compiler encoding
- Expand shade plugin to avoid dependency-reduced POM

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a11017ef4c832e804b73ff4e2f3f46