### PR TITLE
Use & color codes in admin category list

### DIFF
--- a/src/main/java/com/yourorg/servershop/commands/AdminCommand.java
+++ b/src/main/java/com/yourorg/servershop/commands/AdminCommand.java
@@ -40,14 +40,15 @@ public final class AdminCommand {
         if (args.length == 0) { helpCategory(sender); return true; }
         String sub = args[0].toLowerCase();
         if (sub.equals("list")) {
-            StringBuilder sb = new StringBuilder("Categories: ");
+            StringBuilder sb = new StringBuilder("&eCategories: &r");
             for (String c : plugin.categorySettings().categories()) {
                 boolean en = plugin.categorySettings().isEnabled(c);
                 double m = plugin.categorySettings().multiplier(c);
-                sb.append(ChatColor.YELLOW).append(c).append(ChatColor.GRAY).append("[")
-                        .append(en?"on":"off").append(", x").append(m).append("] ");
+                sb.append("&e").append(c).append("&7[")
+                  .append(en ? "on" : "off")
+                  .append(", x").append(m).append("] ");
             }
-            sender.sendMessage(sb.toString());
+            sender.sendMessage(ChatColor.translateAlternateColorCodes('&', sb.toString()));
             return true;
         }
         if (sub.equals("setmult") && args.length >= 3) {


### PR DESCRIPTION
## Summary
- colorize admin category list via `&` codes and ChatColor translation

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1101bfd90832e840d4ae45da517eb