### PR TITLE
Apply dynamic multiplier updates to Sell All command

### DIFF
--- a/src/main/java/com/yourorg/servershop/gui/SellMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/SellMenu.java
@@ -63,7 +63,7 @@ public final class SellMenu implements MenuView {
             total += amount; stacks++;
             p.getInventory().setItem(i, null);
             plugin.logger().logAsync(new com.yourorg.servershop.logging.Transaction(java.time.Instant.now(), p.getName(), com.yourorg.servershop.logging.Transaction.Type.SELL, m, qty, amount));
-            // TODO: consider calling plugin.dynamic().adjustOnSell(m, qty) per TODO list
+            plugin.dynamic().adjustOnSell(m, qty);
         }
         if (total > 0) plugin.economy().depositPlayer(p, total);
         p.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.soldall").replace("%count%", String.valueOf(stacks)).replace("%total%", String.format("%.2f", total))));


### PR DESCRIPTION
## Summary
- Update SellMenu's sell-all operation to invoke `adjustOnSell` so dynamic pricing multipliers decrease as items are sold

## Testing
- `mvn -e test` *(fails: Could not transfer artifact maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a11020f224832e85caa1073ef308c8