### PR TITLE
Add pagination to items menu

### DIFF
--- a/src/main/java/com/yourorg/servershop/gui/CategoryMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/CategoryMenu.java
@@ -36,7 +36,7 @@ public final class CategoryMenu implements MenuView {
         if (name.contains("Sell")) { plugin.menus().openSell(p); return; }
         String clean = org.bukkit.ChatColor.stripColor(name);
         if (!plugin.categorySettings().isEnabled(clean)) { p.sendMessage(plugin.prefixed("Category disabled.")); return; }
-        plugin.menus().openItems(p, clean);
+        plugin.menus().openItems(p, clean, 0);
     }
 
     @Override public String title() { return plugin.getConfig().getString("gui.titles.categories", "Server Shop"); }

--- a/src/main/java/com/yourorg/servershop/gui/ItemsMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/ItemsMenu.java
@@ -10,43 +10,53 @@ import org.bukkit.inventory.Inventory;
 import java.util.List;
 
 public final class ItemsMenu implements MenuView {
-    private final ServerShopPlugin plugin; private final String category;
-    public ItemsMenu(ServerShopPlugin plugin, String category) { this.plugin = plugin; this.category = category; }
+    private static final int PAGE_SIZE = 42;
+    private final ServerShopPlugin plugin;
+    private final String category;
+    private final int page;
+
+    public ItemsMenu(ServerShopPlugin plugin, String category, int page) {
+        this.plugin = plugin; this.category = category; this.page = Math.max(0, page);
+    }
 
     @Override public Inventory build() {
-        int rows = Math.max(1, plugin.getConfig().getInt("gui.rows.items", 6));
-        Inventory inv = Bukkit.createInventory(null, rows*9, title());
+        Inventory inv = Bukkit.createInventory(null, 6*9, title());
         var mats = plugin.catalog().categories().getOrDefault(category, List.of());
+        int start = page * PAGE_SIZE;
+        int end = Math.min(mats.size(), start + PAGE_SIZE);
         int i = 10;
-        for (var m : mats) {
+        for (int idx = start; idx < end; idx++) {
+            var m = mats.get(idx);
             double buy = plugin.shop().priceBuy(m);
             double sell = plugin.shop().priceSell(m);
             inv.setItem(i, GuiUtil.item(m.isItem() ? m : Material.BOOK, "&e"+m.name(), GuiUtil.lore(
                     "&7Buy: &a$"+String.format("%.2f", buy),
                     "&7Sell: &6$"+(sell>0?String.format("%.2f", sell):"-"),
                     "&8Left-click: buy 1  |  Shift-left: buy 16",
-                    "&8Right-click: show price"
-            )));
+                    "&8Right-click: show price")));
             i += (i % 9 == 7) ? 3 : 1;
         }
+        if (page > 0)
+            inv.setItem(6*9-9, GuiUtil.item(Material.ARROW, "&aPrevious Page", GuiUtil.lore("&7Go to page "+page)));
+        if (end < mats.size())
+            inv.setItem(6*9-1, GuiUtil.item(Material.ARROW, "&aNext Page", GuiUtil.lore("&7Go to page "+(page+2))));
+        inv.setItem(6*9-5, GuiUtil.item(Material.BOOK, "&bPage "+(page+1)+"/"+Math.max(1, (int)Math.ceil(mats.size()/(double)PAGE_SIZE)), java.util.List.of()));
         return inv;
     }
 
     @Override public void onClick(InventoryClickEvent e) {
         if (!(e.getWhoClicked() instanceof Player p)) return;
-        var it = e.getCurrentItem(); if (it == null) return;
-        var mat = it.getType();
-        if (mat == null || mat == Material.AIR) return;
-        var m = org.bukkit.Material.matchMaterial(org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName()));
+        var it = e.getCurrentItem(); if (it == null || it.getItemMeta() == null) return;
+        String name = org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName());
+        if (name.equalsIgnoreCase("Previous Page")) { plugin.menus().openItems(p, category, Math.max(0, page-1)); return; }
+        if (name.equalsIgnoreCase("Next Page")) { plugin.menus().openItems(p, category, page+1); return; }
+        var m = org.bukkit.Material.matchMaterial(name);
         if (m == null) return;
-        if (e.isRightClick()) {
-            double buy = plugin.shop().priceBuy(m);
-            p.sendMessage(plugin.prefixed(m.name()+": $"+String.format("%.2f", buy)));
-            return;
-        }
+        if (e.isRightClick()) { double buy = plugin.shop().priceBuy(m); p.sendMessage(plugin.prefixed(m.name()+": $"+String.format("%.2f", buy))); return; }
         int qty = e.isShiftClick() ? 16 : 1;
         plugin.shop().buy(p, m, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
     }
 
-    @Override public String title() { return plugin.getConfig().getString("gui.titles.items", "%category%").replace("%category%", category); }
+    @Override public String title() { return plugin.getConfig().getString("gui.titles.items", "%category%").replace("%category%", category+" ("+(page+1)+")"); }
 }
+

--- a/src/main/java/com/yourorg/servershop/gui/MenuManager.java
+++ b/src/main/java/com/yourorg/servershop/gui/MenuManager.java
@@ -15,7 +15,8 @@ public final class MenuManager implements Listener {
     public MenuManager(ServerShopPlugin plugin) { this.plugin = plugin; }
 
     public void openCategories(Player p) { open(p, new CategoryMenu(plugin)); }
-    public void openItems(Player p, String category) { open(p, new ItemsMenu(plugin, category)); }
+    public void openItems(Player p, String category) { open(p, new ItemsMenu(plugin, category, 0)); }
+    public void openItems(Player p, String category, int page) { open(p, new ItemsMenu(plugin, category, page)); }
     public void openWeekly(Player p) { if (p!=null) open(p, new WeeklyMenu(plugin)); }
     public void openSell(Player p) { open(p, new SellMenu(plugin)); }
     public void openSearch(Player p, String query, java.util.List<org.bukkit.Material> results) { open(p, new SearchMenu(plugin, query, results, 0)); }


### PR DESCRIPTION
## Summary
- Add page handling to items menu
- Allow navigating item pages from menu manager
- Ensure categories open first page of items menu

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a110248d2c832eb1b8eacb6b42067f