### PR TITLE
Add alias-based search with category filter

### DIFF
--- a/src/main/java/com/yourorg/servershop/gui/SearchMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/SearchMenu.java
@@ -30,7 +30,8 @@ public final class SearchMenu implements MenuView {
             if (!plugin.categorySettings().isEnabled(plugin.catalog().categoryOf(m))) continue;
             double buy = plugin.shop().priceBuy(m);
             double sell = plugin.shop().priceSell(m);
-            inv.setItem(i, GuiUtil.item(m.isItem()?m:Material.PAPER, "&e"+m.name(), GuiUtil.lore(
+            String name = plugin.catalog().displayName(m);
+            inv.setItem(i, GuiUtil.item(m.isItem()?m:Material.PAPER, "&e"+name, GuiUtil.lore(
                     "&7Buy: &a$"+String.format("%.2f", buy),
                     "&7Sell: &6$"+(sell>0?String.format("%.2f", sell):"-"),
                     "&8Left-click: buy 1  |  Shift-left: buy 16",
@@ -49,9 +50,8 @@ public final class SearchMenu implements MenuView {
         String name = org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName());
         if (name.equalsIgnoreCase("Previous Page")) { plugin.menus().openSearch(p, query, results, Math.max(0, page-1)); return; }
         if (name.equalsIgnoreCase("Next Page")) { plugin.menus().openSearch(p, query, results, page+1); return; }
-        var m = org.bukkit.Material.matchMaterial(org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName()));
-        if (m == null) return;
-        if (e.isRightClick()) { double buy = plugin.shop().priceBuy(m); p.sendMessage(plugin.prefixed(m.name()+": $"+String.format("%.2f", buy))); return; }
+        Material m = it.getType();
+        if (e.isRightClick()) { double buy = plugin.shop().priceBuy(m); p.sendMessage(plugin.prefixed(plugin.catalog().displayName(m)+": $"+String.format("%.2f", buy))); return; }
         int qty = e.isShiftClick() ? 16 : 1;
         plugin.shop().buy(p, m, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
     }

--- a/src/main/java/com/yourorg/servershop/util/Fuzzy.java
+++ b/src/main/java/com/yourorg/servershop/util/Fuzzy.java
@@ -45,12 +45,19 @@ public final class Fuzzy {
     }
 
     public static java.util.List<Material> rankMaterials(java.util.Collection<Material> mats, String query, int limit, double threshold) {
+        return rankMaterials(mats, m -> java.util.List.of(m.name()), query, limit, threshold);
+    }
+
+    public static java.util.List<Material> rankMaterials(java.util.Collection<Material> mats, java.util.function.Function<Material, ? extends java.util.Collection<String>> names, String query, int limit, double threshold) {
         String q = normalize(query);
         java.util.List<MaterialScore> list = new java.util.ArrayList<>();
         for (Material m : mats) {
-            String name = m.name();
-            double s = similarity(q, name);
-            if (s >= threshold) list.add(new MaterialScore(m, s));
+            double best = 0.0;
+            for (String n : names.apply(m)) {
+                double s = similarity(q, n);
+                if (s > best) best = s;
+            }
+            if (best >= threshold) list.add(new MaterialScore(m, best));
         }
         list.sort((a,b)->{
             int c = Double.compare(b.s, a.s);


### PR DESCRIPTION
## Summary
- support alias/display names in catalog and search
- allow optional category filter for `/shop search`
- show friendly names in search menu

## Testing
- `mvn -q -e test` *(fails: Could not resolve Maven resources plugin)*


------
https://chatgpt.com/codex/tasks/task_e_68a110286644832e96b8cc31a89b55b0