### PR TITLE
Add unit tests and CI workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,8 +27,8 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
+    - name: Build and test with Maven
+      run: mvn -B test --file pom.xml
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,24 @@
       <artifactId>mysql-connector-j</artifactId>
       <version>8.4.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>5.10.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -63,6 +81,14 @@
         <configuration>
           <release>17</release>
           <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.1.2</version>
+        <configuration>
+          <useModulePath>false</useModulePath>
         </configuration>
       </plugin>
       <plugin>

--- a/src/test/java/com/yourorg/servershop/dynamic/DynamicPricingManagerTest.java
+++ b/src/test/java/com/yourorg/servershop/dynamic/DynamicPricingManagerTest.java
@@ -1,0 +1,73 @@
+package com.yourorg.servershop.dynamic;
+
+import com.yourorg.servershop.ServerShopPlugin;
+import com.yourorg.servershop.shop.Catalog;
+import com.yourorg.servershop.shop.PriceModel;
+import com.yourorg.servershop.config.CategorySettings;
+import com.yourorg.servershop.weekly.WeeklyShopManager;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class DynamicPricingManagerTest {
+    @Test
+    public void decaysMultiplierOverTime() throws Exception {
+        Path dataDir = Files.createTempDirectory("data");
+
+        ServerShopPlugin plugin = Mockito.mock(ServerShopPlugin.class);
+        YamlConfiguration cfg = new YamlConfiguration();
+        cfg.set("dynamicPricing.enabled", true);
+        cfg.set("dynamicPricing.initialMultiplier", 1.0);
+        cfg.set("dynamicPricing.minMultiplier", 0.5);
+        cfg.set("dynamicPricing.maxMultiplier", 2.0);
+        cfg.set("dynamicPricing.buyStep", 0.005);
+        cfg.set("dynamicPricing.sellStep", 0.005);
+        cfg.set("dynamicPricing.decay.enabled", true);
+        cfg.set("dynamicPricing.decay.perHourTowards1", 0.5);
+        when(plugin.getConfig()).thenReturn(cfg);
+        when(plugin.getDataFolder()).thenReturn(dataDir.toFile());
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("test"));
+
+        Catalog catalog = Mockito.mock(Catalog.class);
+        when(catalog.allMaterials()).thenReturn(Set.of(Material.STONE));
+        when(catalog.categoryOf(any(Material.class))).thenReturn("blocks");
+        PriceModel pm = Mockito.mock(PriceModel.class);
+        when(pm.clampToBounds(anyDouble(), anyDouble())).thenAnswer(i -> i.getArgument(0));
+        when(catalog.priceModel()).thenReturn(pm);
+        when(plugin.catalog()).thenReturn(catalog);
+
+        WeeklyShopManager weekly = Mockito.mock(WeeklyShopManager.class);
+        when(weekly.isWeekly(any(Material.class))).thenReturn(false);
+        when(plugin.weekly()).thenReturn(weekly);
+
+        CategorySettings catSettings = Mockito.mock(CategorySettings.class);
+        when(catSettings.multiplier(anyString())).thenReturn(1.0);
+        when(plugin.categorySettings()).thenReturn(catSettings);
+
+        DynamicPricingManager mgr = new DynamicPricingManager(plugin);
+
+        Field mapField = DynamicPricingManager.class.getDeclaredField("map");
+        mapField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<Material, PriceState> map = (Map<Material, PriceState>) mapField.get(mgr);
+        PriceState st = map.get(Material.STONE);
+        st.multiplier = 2.0;
+        st.lastUpdateMs = System.currentTimeMillis() - 2 * 3600_000L;
+
+        double price = mgr.buyPrice(Material.STONE, 10.0);
+
+        assertEquals(12.5, price, 0.01);
+        assertEquals(1.25, st.multiplier, 0.01);
+    }
+}

--- a/src/test/java/com/yourorg/servershop/importer/ShopImporterTest.java
+++ b/src/test/java/com/yourorg/servershop/importer/ShopImporterTest.java
@@ -1,0 +1,52 @@
+package com.yourorg.servershop.importer;
+
+import com.yourorg.servershop.ServerShopPlugin;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+public class ShopImporterTest {
+    @Test
+    public void importsValidItems() throws Exception {
+        Path dataDir = Files.createTempDirectory("data");
+        Path importDir = Files.createTempDirectory("import");
+        Path shopsDir = importDir.resolve("shops");
+        Files.createDirectories(shopsDir);
+
+        String yaml = "items:\n" +
+                "  sample:\n" +
+                "    buy-prices:\n" +
+                "      '1':\n" +
+                "        amount: $10\n" +
+                "    sell-prices:\n" +
+                "      '1':\n" +
+                "        amount: $5\n" +
+                "    products:\n" +
+                "      '1':\n" +
+                "        material: STONE\n" +
+                "      '2':\n" +
+                "        material: IRON_SWORD\n";
+        Files.writeString(shopsDir.resolve("Blocks.yml"), yaml);
+
+        ServerShopPlugin plugin = Mockito.mock(ServerShopPlugin.class, Mockito.RETURNS_DEEP_STUBS);
+        when(plugin.getDataFolder()).thenReturn(dataDir.toFile());
+
+        ShopImporter importer = new ShopImporter(plugin);
+        int count = importer.importFrom(importDir.toFile());
+
+        assertEquals(5, count);
+        File outFile = dataDir.resolve("shop.yml").toFile();
+        assertTrue(outFile.isFile());
+        YamlConfiguration out = YamlConfiguration.loadConfiguration(outFile);
+        assertTrue(out.contains("categories.blocks.STONE.buy"));
+        assertEquals(10.0, out.getDouble("categories.blocks.STONE.buy"), 0.001);
+        assertFalse(out.contains("categories.blocks.IRON_SWORD"));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for the shop importer
- add unit tests verifying pricing decay logic
- run tests in GitHub Actions workflow

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a110306dc8832e9fb4102f45f4c24d