### PR TITLE
feat: queue async storage writes

### DIFF
--- a/src/main/java/com/yourorg/servershop/dynamic/PriceStorage.java
+++ b/src/main/java/com/yourorg/servershop/dynamic/PriceStorage.java
@@ -6,5 +6,6 @@ public interface PriceStorage {
     java.util.Map<Material, PriceState> loadAll() throws Exception;
     void save(Material material, PriceState state) throws Exception;
     void saveAll(java.util.Map<Material, PriceState> map) throws Exception;
+    default void flush() throws Exception {}
     void close() throws Exception;
 }

--- a/src/main/java/com/yourorg/servershop/dynamic/SQLPriceStorage.java
+++ b/src/main/java/com/yourorg/servershop/dynamic/SQLPriceStorage.java
@@ -69,5 +69,7 @@ public final class SQLPriceStorage implements PriceStorage {
         }
     }
 
+    @Override public void flush() { }
+
     @Override public void close() { if (ds != null) ds.close(); }
 }

--- a/src/main/java/com/yourorg/servershop/logging/LogStorage.java
+++ b/src/main/java/com/yourorg/servershop/logging/LogStorage.java
@@ -4,5 +4,6 @@ public interface LogStorage {
     void append(Transaction tx) throws Exception;
     java.util.List<Transaction> last(int limit) throws Exception;
     java.util.List<Transaction> lastOf(String player, int limit) throws Exception;
+    default void flush() throws Exception {}
     void close() throws Exception;
 }

--- a/src/main/java/com/yourorg/servershop/logging/LoggerManager.java
+++ b/src/main/java/com/yourorg/servershop/logging/LoggerManager.java
@@ -43,15 +43,21 @@ public final class LoggerManager {
     }
 
     public void logAsync(Transaction tx) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+        plugin.io(() -> {
             try { storage.append(tx); } catch (Exception e) { plugin.getLogger().warning("Failed to log: " + e.getMessage()); }
         });
     }
 
-    public void close() { try { storage.close(); } catch (Exception ignored) { } }
+    public void flush() {
+        try { storage.flush(); } catch (Exception e) { plugin.getLogger().warning("Failed to flush log: " + e.getMessage()); }
+    }
+
+    public void close() {
+        try { storage.flush(); storage.close(); } catch (Exception ignored) { }
+    }
 
     public void lastAsync(String playerOrNull, int limit, java.util.function.Consumer<List<Transaction>> cb) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+        plugin.io(() -> {
             try {
                 List<Transaction> list = (playerOrNull == null) ? storage.last(limit) : storage.lastOf(playerOrNull, limit);
                 Bukkit.getScheduler().runTask(plugin, () -> cb.accept(list));

--- a/src/main/java/com/yourorg/servershop/logging/SQLLogStorage.java
+++ b/src/main/java/com/yourorg/servershop/logging/SQLLogStorage.java
@@ -51,6 +51,7 @@ public final class SQLLogStorage implements LogStorage {
 
     @Override public java.util.List<Transaction> last(int limit) throws Exception { return query(null, limit); }
     @Override public java.util.List<Transaction> lastOf(String player, int limit) throws Exception { return query(player, limit); }
+    @Override public void flush() { }
     @Override public void close() { if (ds != null) ds.close(); }
 
     private java.util.List<Transaction> query(String player, int limit) throws Exception {

--- a/src/main/java/com/yourorg/servershop/logging/YAMLLogStorage.java
+++ b/src/main/java/com/yourorg/servershop/logging/YAMLLogStorage.java
@@ -3,19 +3,26 @@ package com.yourorg.servershop.logging;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 public final class YAMLLogStorage implements LogStorage {
-    private final File file; private final int maxEntries;
+    private final File file;
+    private final int maxEntries;
+    private final List<Map<String, Object>> entries;
 
     public YAMLLogStorage(File dataFolder, int maxEntries) {
         this.file = new File(dataFolder, "transactions.yml");
         this.maxEntries = Math.max(100, maxEntries);
+        this.entries = (List<Map<String, Object>>) YamlConfiguration.loadConfiguration(file)
+                .getList("entries", new ArrayList<>());
     }
 
-    @Override public synchronized void append(Transaction tx) throws Exception {
-        YamlConfiguration y = load();
-        java.util.List<java.util.Map<String, Object>> entries = (java.util.List<java.util.Map<String, Object>>) y.getList("entries", new java.util.ArrayList<>());
-        java.util.Map<String, Object> row = new java.util.LinkedHashMap<>();
+    @Override public synchronized void append(Transaction tx) {
+        Map<String, Object> row = new LinkedHashMap<>();
         row.put("time", tx.time.toEpochMilli());
         row.put("player", tx.player);
         row.put("type", tx.type.name());
@@ -24,22 +31,25 @@ public final class YAMLLogStorage implements LogStorage {
         row.put("amount", tx.amount);
         entries.add(row);
         while (entries.size() > maxEntries) entries.remove(0);
+    }
+
+    @Override public synchronized List<Transaction> last(int limit) { return filter(null, limit); }
+    @Override public synchronized List<Transaction> lastOf(String player, int limit) { return filter(player.toLowerCase(Locale.ROOT), limit); }
+
+    @Override public synchronized void flush() throws Exception {
+        YamlConfiguration y = new YamlConfiguration();
         y.set("entries", entries);
         y.save(file);
     }
 
-    @Override public synchronized java.util.List<Transaction> last(int limit) throws Exception { return filter(null, limit); }
-    @Override public synchronized java.util.List<Transaction> lastOf(String player, int limit) throws Exception { return filter(player.toLowerCase(java.util.Locale.ROOT), limit); }
-    @Override public void close() { }
+    @Override public void close() { try { flush(); } catch (Exception ignored) { } }
 
-    private java.util.List<Transaction> filter(String playerLower, int limit) throws Exception {
-        YamlConfiguration y = load();
-        java.util.List<java.util.Map<String, Object>> entries = (java.util.List<java.util.Map<String, Object>>) y.getList("entries", java.util.Collections.emptyList());
-        java.util.List<Transaction> list = new java.util.ArrayList<>();
+    private List<Transaction> filter(String playerLower, int limit) {
+        List<Transaction> list = new ArrayList<>();
         for (int i = entries.size() - 1; i >= 0 && list.size() < limit; i--) {
-            java.util.Map<String, Object> e = entries.get(i);
+            Map<String, Object> e = entries.get(i);
             String p = String.valueOf(e.get("player"));
-            if (playerLower != null && !p.toLowerCase(java.util.Locale.ROOT).equals(playerLower)) continue;
+            if (playerLower != null && !p.toLowerCase(Locale.ROOT).equals(playerLower)) continue;
             Transaction t = new Transaction(
                     java.time.Instant.ofEpochMilli(((Number) e.get("time")).longValue()),
                     p,
@@ -52,6 +62,4 @@ public final class YAMLLogStorage implements LogStorage {
         }
         return list;
     }
-
-    private YamlConfiguration load() { return YamlConfiguration.loadConfiguration(file); }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,6 +8,8 @@ priceModel:
   minFactor: 0.5
   maxFactor: 1.5
   sellStep: 0.01
+storage:
+  flushSeconds: 10
 logging:
   storage: YAML  # YAML or MYSQL
   maxEntries: 1000


### PR DESCRIPTION
## Summary
- route price saving and transaction logging through a single-thread executor
- buffer YAML price and log entries and flush them on a timer
- expose `storage.flushSeconds` in config

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a11129ceb0832e8ea749aeb1488d74