### PR TITLE
Add scheduled multiplier decay toward base prices

### DIFF
--- a/src/main/java/com/yourorg/servershop/ServerShopPlugin.java
+++ b/src/main/java/com/yourorg/servershop/ServerShopPlugin.java
@@ -44,6 +44,13 @@ public final class ServerShopPlugin extends JavaPlugin {
         int saveEvery = Math.max(1, getConfig().getInt("dynamicPricing.decay.saveEveryMinutes", 5));
         Bukkit.getScheduler().runTaskTimerAsynchronously(this, dynamic::tickSaveAll, 20L * 60L * saveEvery, 20L * 60L * saveEvery);
 
+        double decayFactor = getConfig().getDouble("decayToOne.factor", 0.05);
+        long hour = 20L * 60L * 60L;
+        Bukkit.getScheduler().runTaskTimerAsynchronously(this, () -> {
+            categorySettings.decayTowardsOne(decayFactor, catalog.priceModel().minFactor(), catalog.priceModel().maxFactor());
+            dynamic.decayTowardsOne(decayFactor);
+        }, hour, hour);
+
         getCommand("shop").setExecutor(new ShopCommand(this));
         getCommand("sell").setExecutor(new SellCommand(this));
         getCommand("sellall").setExecutor(new SellAllCommand(this));

--- a/src/main/java/com/yourorg/servershop/config/CategorySettings.java
+++ b/src/main/java/com/yourorg/servershop/config/CategorySettings.java
@@ -30,6 +30,17 @@ public final class CategorySettings {
     public synchronized void setMultiplier(String name, double m) { ensureCategory(name); map.get(name).multiplier = Math.max(0.0, m); save(); }
     public synchronized Set<String> categories() { return new LinkedHashSet<>(map.keySet()); }
 
+    public synchronized void decayTowardsOne(double factor, double min, double max) {
+        boolean changed = false;
+        for (Entry e : map.values()) {
+            double m = e.multiplier;
+            if (m < min || m > max) continue;
+            e.multiplier = m + (1.0 - m) * factor;
+            changed = true;
+        }
+        if (changed) save();
+    }
+
     public synchronized void load() {
         map.clear();
         YamlConfiguration y = YamlConfiguration.loadConfiguration(file);

--- a/src/main/java/com/yourorg/servershop/dynamic/DynamicPricingManager.java
+++ b/src/main/java/com/yourorg/servershop/dynamic/DynamicPricingManager.java
@@ -105,6 +105,19 @@ public final class DynamicPricingManager {
         });
     }
 
+    public synchronized void decayTowardsOne(double factor) {
+        if (!enabled) return;
+        for (var st : map.values()) {
+            double m = st.multiplier;
+            if (m < minMult || m > maxMult) continue;
+            st.multiplier = clampMult(m + (1.0 - m) * factor);
+            st.lastUpdateMs = System.currentTimeMillis();
+        }
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try { storage.saveAll(new java.util.EnumMap<>(map)); } catch (Exception e) { plugin.getLogger().warning("Failed to save prices: "+e.getMessage()); }
+        });
+    }
+
     public synchronized void close() {
         try { storage.saveAll(map); storage.close(); } catch (Exception ignored) { }
     }

--- a/src/main/java/com/yourorg/servershop/shop/PriceModel.java
+++ b/src/main/java/com/yourorg/servershop/shop/PriceModel.java
@@ -19,4 +19,7 @@ public final class PriceModel {
     }
 
     public double afterSold(double current) { return current * (1.0 - sellStep); }
+
+    public double minFactor() { return minFactor; }
+    public double maxFactor() { return maxFactor; }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -35,6 +35,8 @@ dynamicPricing:
     enabled: true
     perHourTowards1: 0.02
     saveEveryMinutes: 5
+decayToOne:
+  factor: 0.05
 gui:
   titles:
     categories: '&8Server Shop'


### PR DESCRIPTION
## Summary
- schedule hourly task to nudge category and item multipliers toward 1.0
- expose min/max price factors and provide decay helpers
- add config option `decayToOne.factor`

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*
- `mvn -q -e -o package` *(fails: Cannot access central in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68a1112e8144832e8f46cffdf70c776e