### PR TITLE
Enforce category permissions for /sell

### DIFF
--- a/src/main/java/com/yourorg/servershop/shop/ShopService.java
+++ b/src/main/java/com/yourorg/servershop/shop/ShopService.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import java.time.Instant;
+import java.util.Locale;
 import java.util.Optional;
 
 public final class ShopService {
@@ -42,6 +43,8 @@ public final class ShopService {
         if (opt.isEmpty() || !opt.get().canSell()) return Optional.of(msg("not-sellable").replace("%material%", mat.name()));
         String cat = plugin.catalog().categoryOf(mat);
         if (!plugin.categorySettings().isEnabled(cat)) return Optional.of("Category disabled: "+cat);
+        if (!p.hasPermission("servershop.category." + cat.toLowerCase(Locale.ROOT)))
+            return Optional.of("No permission for category: " + cat);
         int removed = removeFromInventory(p, mat, qty);
         if (removed <= 0) return Optional.of("You don't have that.");
         double unit = plugin.dynamic().sellPrice(mat, opt.get().sellPrice());


### PR DESCRIPTION
## Summary
- require servershop.category.<category> permission before selling items
- ensure /sell respects disabled categories and category permissions like /sellall

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a11139f638832eaacbbd2a535e4962