### PR TITLE
feat: add paginated shop menus

### DIFF
--- a/src/main/java/com/yourorg/servershop/gui/CategoryMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/CategoryMenu.java
@@ -4,40 +4,52 @@ import com.yourorg.servershop.ServerShopPlugin;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public final class CategoryMenu implements MenuView {
-    private final ServerShopPlugin plugin;
-    public CategoryMenu(ServerShopPlugin plugin) { this.plugin = plugin; }
+    private static final int PAGE_SIZE = 12;
+    private final ServerShopPlugin plugin; private final int page;
+    public CategoryMenu(ServerShopPlugin plugin, int page) { this.plugin = plugin; this.page = Math.max(0, page); }
 
     @Override public Inventory build() {
         int rows = Math.max(1, plugin.getConfig().getInt("gui.rows.categories", 3));
         Inventory inv = Bukkit.createInventory(null, rows*9, title());
-        int slot = 10;
-        for (String cat : plugin.catalog().categories().keySet()) {
-            if (!plugin.categorySettings().isEnabled(cat)) continue;
+        List<String> cats = new ArrayList<>();
+        for (String c : plugin.catalog().categories().keySet()) if (plugin.categorySettings().isEnabled(c)) cats.add(c);
+        int start = page * PAGE_SIZE;
+        int end = Math.min(cats.size(), start + PAGE_SIZE);
+        int[] slots = {10,11,12,13,14,15,16,19,20,21,24,25};
+        int ptr = 0;
+        for (int idx = start; idx < end && ptr < slots.length; idx++) {
+            String cat = cats.get(idx);
             List<Material> mats = plugin.catalog().categories().get(cat);
             Material icon = (mats != null && !mats.isEmpty() && mats.get(0).isItem()) ? mats.get(0) : Material.CHEST;
-            inv.setItem(slot, GuiUtil.item(icon, "&e"+cat, GuiUtil.lore("&7Click to view items")));
-            slot += (slot % 9 == 7) ? 3 : 1;
+            inv.setItem(slots[ptr++], GuiUtil.item(icon, "&e"+cat, GuiUtil.lore("&7Click to view items")));
         }
+        if (page > 0) inv.setItem(rows*9-9, GuiUtil.item(Material.ARROW, "&aPrevious Page", GuiUtil.lore("&7Page "+page)));
+        if (end < cats.size()) inv.setItem(rows*9-1, GuiUtil.item(Material.ARROW, "&aNext Page", GuiUtil.lore("&7Page "+(page+2))));
+        inv.setItem(4, GuiUtil.item(Material.BOOK, "&bPage "+(page+1)+"/"+Math.max(1, (int)Math.ceil(cats.size()/(double)PAGE_SIZE)), java.util.List.of()));
         inv.setItem(rows*9-5, GuiUtil.item(Material.CLOCK, "&bWeekly Picks", GuiUtil.lore("&7Weekly discounts")));
         inv.setItem(rows*9-4, GuiUtil.item(Material.GOLD_INGOT, "&aSell Items", GuiUtil.lore("&7Sell your loot")));
         return inv;
     }
 
-    @Override public void onClick(org.bukkit.event.inventory.InventoryClickEvent e) {
+    @Override public void onClick(InventoryClickEvent e) {
         if (!(e.getWhoClicked() instanceof Player p)) return;
-        var it = e.getCurrentItem(); if (it == null) return;
-        var name = it.getItemMeta() != null ? it.getItemMeta().getDisplayName() : "";
+        var it = e.getCurrentItem(); if (it == null || it.getItemMeta() == null) return;
+        String name = org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName());
+        if (name.equalsIgnoreCase("Previous Page")) { plugin.menus().openCategories(p, Math.max(0, page-1)); return; }
+        if (name.equalsIgnoreCase("Next Page")) { plugin.menus().openCategories(p, page+1); return; }
         if (name.contains("Weekly")) { plugin.menus().openWeekly(p); return; }
         if (name.contains("Sell")) { plugin.menus().openSell(p); return; }
-        String clean = org.bukkit.ChatColor.stripColor(name);
-        if (!plugin.categorySettings().isEnabled(clean)) { p.sendMessage(plugin.prefixed("Category disabled.")); return; }
-        plugin.menus().openItems(p, clean);
+        if (!plugin.categorySettings().isEnabled(name)) { p.sendMessage(plugin.prefixed("Category disabled.")); return; }
+        plugin.menus().openItems(p, name, 0);
     }
 
     @Override public String title() { return plugin.getConfig().getString("gui.titles.categories", "Server Shop"); }
 }
+

--- a/src/main/java/com/yourorg/servershop/gui/ConfirmMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/ConfirmMenu.java
@@ -1,0 +1,42 @@
+package com.yourorg.servershop.gui;
+
+import com.yourorg.servershop.ServerShopPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+
+import java.util.function.Consumer;
+
+public final class ConfirmMenu implements MenuView {
+    private final ServerShopPlugin plugin; private final Material mat; private final int qty; private final Consumer<Player> back;
+    public ConfirmMenu(ServerShopPlugin plugin, Material mat, int qty, Consumer<Player> back) { this.plugin = plugin; this.mat = mat; this.qty = qty; this.back = back; }
+
+    @Override public Inventory build() {
+        Inventory inv = Bukkit.createInventory(null, 3*9, title());
+        double unit = plugin.shop().priceBuy(mat);
+        double total = unit * qty;
+        inv.setItem(13, GuiUtil.item(mat.isItem()?mat:Material.BOOK, "&e"+mat.name(), GuiUtil.lore(
+                "&7Qty: &f"+qty,
+                "&7Price: &a$"+String.format("%.2f", total))));
+        inv.setItem(11, GuiUtil.item(Material.LIME_WOOL, "&aConfirm", GuiUtil.lore("&7Complete purchase")));
+        inv.setItem(15, GuiUtil.item(Material.RED_WOOL, "&cCancel", GuiUtil.lore("&7Go back")));
+        return inv;
+    }
+
+    @Override public void onClick(InventoryClickEvent e) {
+        if (!(e.getWhoClicked() instanceof Player p)) return;
+        var it = e.getCurrentItem(); if (it == null || it.getItemMeta() == null) return;
+        String name = org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName());
+        if (name.equalsIgnoreCase("Confirm")) {
+            plugin.shop().buy(p, mat, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
+            back.accept(p);
+        } else if (name.equalsIgnoreCase("Cancel")) {
+            back.accept(p);
+        }
+    }
+
+    @Override public String title() { return plugin.getConfig().getString("gui.titles.confirm", "Confirm Purchase"); }
+}
+

--- a/src/main/java/com/yourorg/servershop/gui/ItemsMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/ItemsMenu.java
@@ -10,15 +10,19 @@ import org.bukkit.inventory.Inventory;
 import java.util.List;
 
 public final class ItemsMenu implements MenuView {
-    private final ServerShopPlugin plugin; private final String category;
-    public ItemsMenu(ServerShopPlugin plugin, String category) { this.plugin = plugin; this.category = category; }
+    private static final int PAGE_SIZE = 42;
+    private final ServerShopPlugin plugin; private final String category; private final int page;
+    public ItemsMenu(ServerShopPlugin plugin, String category, int page) { this.plugin = plugin; this.category = category; this.page = Math.max(0, page); }
 
     @Override public Inventory build() {
         int rows = Math.max(1, plugin.getConfig().getInt("gui.rows.items", 6));
         Inventory inv = Bukkit.createInventory(null, rows*9, title());
         var mats = plugin.catalog().categories().getOrDefault(category, List.of());
+        int start = page * PAGE_SIZE;
+        int end = Math.min(mats.size(), start + PAGE_SIZE);
         int i = 10;
-        for (var m : mats) {
+        for (int idx = start; idx < end; idx++) {
+            var m = mats.get(idx);
             double buy = plugin.shop().priceBuy(m);
             double sell = plugin.shop().priceSell(m);
             inv.setItem(i, GuiUtil.item(m.isItem() ? m : Material.BOOK, "&e"+m.name(), GuiUtil.lore(
@@ -29,15 +33,19 @@ public final class ItemsMenu implements MenuView {
             )));
             i += (i % 9 == 7) ? 3 : 1;
         }
+        if (page > 0) inv.setItem(rows*9-9, GuiUtil.item(Material.ARROW, "&aPrevious Page", GuiUtil.lore("&7Page "+page)));
+        if (end < mats.size()) inv.setItem(rows*9-1, GuiUtil.item(Material.ARROW, "&aNext Page", GuiUtil.lore("&7Page "+(page+2))));
+        inv.setItem(rows*9-5, GuiUtil.item(Material.BOOK, "&bPage "+(page+1)+"/"+Math.max(1, (int)Math.ceil(mats.size()/(double)PAGE_SIZE)), java.util.List.of()));
         return inv;
     }
 
     @Override public void onClick(InventoryClickEvent e) {
         if (!(e.getWhoClicked() instanceof Player p)) return;
-        var it = e.getCurrentItem(); if (it == null) return;
-        var mat = it.getType();
-        if (mat == null || mat == Material.AIR) return;
-        var m = org.bukkit.Material.matchMaterial(org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName()));
+        var it = e.getCurrentItem(); if (it == null || it.getItemMeta() == null) return;
+        String name = org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName());
+        if (name.equalsIgnoreCase("Previous Page")) { plugin.menus().openItems(p, category, Math.max(0, page-1)); return; }
+        if (name.equalsIgnoreCase("Next Page")) { plugin.menus().openItems(p, category, page+1); return; }
+        var m = org.bukkit.Material.matchMaterial(name);
         if (m == null) return;
         if (e.isRightClick()) {
             double buy = plugin.shop().priceBuy(m);
@@ -45,8 +53,15 @@ public final class ItemsMenu implements MenuView {
             return;
         }
         int qty = e.isShiftClick() ? 16 : 1;
-        plugin.shop().buy(p, m, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
+        double total = plugin.shop().priceBuy(m) * qty;
+        double threshold = plugin.getConfig().getDouble("gui.confirmThreshold", 1000.0);
+        if (total >= threshold) {
+            plugin.menus().openConfirm(p, m, qty, pl -> plugin.menus().openItems(pl, category, page));
+        } else {
+            plugin.shop().buy(p, m, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
+        }
     }
 
     @Override public String title() { return plugin.getConfig().getString("gui.titles.items", "%category%").replace("%category%", category); }
 }
+

--- a/src/main/java/com/yourorg/servershop/gui/MenuManager.java
+++ b/src/main/java/com/yourorg/servershop/gui/MenuManager.java
@@ -14,12 +14,15 @@ public final class MenuManager implements Listener {
 
     public MenuManager(ServerShopPlugin plugin) { this.plugin = plugin; }
 
-    public void openCategories(Player p) { open(p, new CategoryMenu(plugin)); }
-    public void openItems(Player p, String category) { open(p, new ItemsMenu(plugin, category)); }
+    public void openCategories(Player p) { openCategories(p, 0); }
+    public void openCategories(Player p, int page) { open(p, new CategoryMenu(plugin, page)); }
+    public void openItems(Player p, String category) { openItems(p, category, 0); }
+    public void openItems(Player p, String category, int page) { open(p, new ItemsMenu(plugin, category, page)); }
     public void openWeekly(Player p) { if (p!=null) open(p, new WeeklyMenu(plugin)); }
     public void openSell(Player p) { open(p, new SellMenu(plugin)); }
     public void openSearch(Player p, String query, java.util.List<org.bukkit.Material> results) { open(p, new SearchMenu(plugin, query, results, 0)); }
     public void openSearch(Player p, String query, java.util.List<org.bukkit.Material> results, int page) { open(p, new SearchMenu(plugin, query, results, page)); }
+    public void openConfirm(Player p, org.bukkit.Material mat, int qty, java.util.function.Consumer<Player> back) { open(p, new ConfirmMenu(plugin, mat, qty, back)); }
 
     private void open(Player p, MenuView view) {
         Inventory inv = view.build();

--- a/src/main/java/com/yourorg/servershop/gui/SearchMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/SearchMenu.java
@@ -53,7 +53,13 @@ public final class SearchMenu implements MenuView {
         if (m == null) return;
         if (e.isRightClick()) { double buy = plugin.shop().priceBuy(m); p.sendMessage(plugin.prefixed(m.name()+": $"+String.format("%.2f", buy))); return; }
         int qty = e.isShiftClick() ? 16 : 1;
-        plugin.shop().buy(p, m, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
+        double total = plugin.shop().priceBuy(m) * qty;
+        double threshold = plugin.getConfig().getDouble("gui.confirmThreshold", 1000.0);
+        if (total >= threshold) {
+            plugin.menus().openConfirm(p, m, qty, pl -> plugin.menus().openSearch(pl, query, results, page));
+        } else {
+            plugin.shop().buy(p, m, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
+        }
     }
 
     @Override public String title() { return plugin.getConfig().getString("gui.titles.items", "%category%").replace("%category%", "Search: "+query+" ("+(page+1)+")"); }

--- a/src/main/java/com/yourorg/servershop/gui/WeeklyMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/WeeklyMenu.java
@@ -30,7 +30,13 @@ public final class WeeklyMenu implements MenuView {
         var m = org.bukkit.Material.matchMaterial(org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName()));
         if (m == null) return;
         int qty = e.isShiftClick() ? 16 : 1;
-        plugin.shop().buy(p, m, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
+        double total = plugin.shop().priceBuy(m) * qty;
+        double threshold = plugin.getConfig().getDouble("gui.confirmThreshold", 1000.0);
+        if (total >= threshold) {
+            plugin.menus().openConfirm(p, m, qty, pl -> plugin.menus().openWeekly(pl));
+        } else {
+            plugin.shop().buy(p, m, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
+        }
     }
 
     @Override public String title() { return plugin.getConfig().getString("gui.titles.weekly", "Weekly Picks"); }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -36,11 +36,13 @@ dynamicPricing:
     perHourTowards1: 0.02
     saveEveryMinutes: 5
 gui:
+  confirmThreshold: 1000.0
   titles:
     categories: '&8Server Shop'
     items: '&8%category%'
     weekly: '&8Weekly Picks'
     sell: '&8Sell Items'
+    confirm: '&8Confirm Purchase'
   rows:
     categories: 3
     items: 6


### PR DESCRIPTION
## Summary
- add pagination and navigation to category and item shop menus
- introduce confirm screen for costly purchases and integrate with search/weekly menus
- expose confirmation threshold and title in config

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a111444078832e852f719d901ae558