### PR TITLE
feat: add configurable sell spread

### DIFF
--- a/src/main/java/com/yourorg/servershop/dynamic/DynamicPricingManager.java
+++ b/src/main/java/com/yourorg/servershop/dynamic/DynamicPricingManager.java
@@ -70,8 +70,9 @@ public final class DynamicPricingManager {
         double mult = currentMultiplier(m);
         String cat = plugin.catalog().categoryOf(m);
         double catMult = plugin.categorySettings().multiplier(cat);
-        double price = base * mult * catMult;
-        return clampToBounds(price, base);
+        double sm = plugin.catalog().priceModel().sellMultiplier();
+        double price = base * sm * mult * catMult;
+        return clampToBounds(price, base * sm);
     }
 
     public synchronized void adjustOnBuy(Material m, int qty) {

--- a/src/main/java/com/yourorg/servershop/shop/PriceModel.java
+++ b/src/main/java/com/yourorg/servershop/shop/PriceModel.java
@@ -3,13 +3,14 @@ package com.yourorg.servershop.shop;
 import org.bukkit.configuration.file.FileConfiguration;
 
 public final class PriceModel {
-    private final double minFactor, maxFactor, sellStep;
+    private final double minFactor, maxFactor, sellStep, sellMultiplier;
 
     public PriceModel(FileConfiguration cfg) {
         var sec = cfg.getConfigurationSection("priceModel");
         this.minFactor = sec.getDouble("minFactor", 0.5);
         this.maxFactor = sec.getDouble("maxFactor", 1.5);
         this.sellStep = sec.getDouble("sellStep", 0.01);
+        this.sellMultiplier = sec.getDouble("sellMultiplier", 0.8);
     }
 
     public double clampToBounds(double value, double base) {
@@ -19,4 +20,5 @@ public final class PriceModel {
     }
 
     public double afterSold(double current) { return current * (1.0 - sellStep); }
+    public double sellMultiplier() { return sellMultiplier; }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,6 +8,7 @@ priceModel:
   minFactor: 0.5
   maxFactor: 1.5
   sellStep: 0.01
+  sellMultiplier: 0.8 # players sell at 80% of the base price
 logging:
   storage: YAML  # YAML or MYSQL
   maxEntries: 1000


### PR DESCRIPTION
## Summary
- add `sellMultiplier` config to control buy/sell spread
- factor `sellMultiplier` into dynamic selling price calculations

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a111474740832e8706dffed72beb0b