### PR TITLE
Add locale-aware alias support with player locale detection

### DIFF
--- a/src/main/java/com/yourorg/servershop/commands/SellCommand.java
+++ b/src/main/java/com/yourorg/servershop/commands/SellCommand.java
@@ -12,7 +12,7 @@ public final class SellCommand implements CommandExecutor {
     @Override public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
         if (!(sender instanceof Player p)) { sender.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.not-a-player"))); return true; }
         if (args.length < 2) { p.sendMessage(plugin.prefixed("/sell <material> <qty>")); return true; }
-        Material mat = Util.parseMaterial(args[1]);
+        Material mat = Util.parseMaterial(plugin, p, args[1]);
         int qty; try { qty = Math.max(1, Integer.parseInt(args.length > 2 ? args[2] : "1")); } catch (Exception e) { qty = 1; }
         if (mat == null) { p.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.unknown-material").replace("%material%", args[1]))); return true; }
         plugin.shop().sell(p, mat, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));

--- a/src/main/java/com/yourorg/servershop/commands/Util.java
+++ b/src/main/java/com/yourorg/servershop/commands/Util.java
@@ -1,10 +1,15 @@
 package com.yourorg.servershop.commands;
 
+import com.yourorg.servershop.ServerShopPlugin;
 import org.bukkit.Material;
+import org.bukkit.command.CommandSender;
 
 public final class Util {
-    public static Material parseMaterial(String raw) {
+    public static Material parseMaterial(ServerShopPlugin plugin, CommandSender sender, String raw) {
         if (raw == null) return null;
+        String lang = plugin.locale(sender);
+        Material viaAlias = plugin.aliases().match(raw, lang);
+        if (viaAlias != null) return viaAlias;
         return Material.matchMaterial(raw.toUpperCase().replace('-', '_').replace(' ', '_'));
     }
 }

--- a/src/main/java/com/yourorg/servershop/config/AliasManager.java
+++ b/src/main/java/com/yourorg/servershop/config/AliasManager.java
@@ -1,0 +1,74 @@
+package com.yourorg.servershop.config;
+
+import com.yourorg.servershop.ServerShopPlugin;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * Loads per-locale alias mappings from aliases-<lang>.yml files.
+ */
+public final class AliasManager {
+    private final ServerShopPlugin plugin;
+    private final String defaultLang;
+    private final Map<String, Map<String, Material>> byLang = new HashMap<>();
+    private final Map<String, Map<Material, Set<String>>> reverse = new HashMap<>();
+
+    public AliasManager(ServerShopPlugin plugin, String defaultLang) {
+        this.plugin = plugin;
+        this.defaultLang = defaultLang.toLowerCase(Locale.ROOT);
+        reload();
+    }
+
+    public void reload() {
+        byLang.clear();
+        reverse.clear();
+        File dir = plugin.getDataFolder();
+        File[] files = dir.listFiles((d, n) -> n.startsWith("aliases-") && n.endsWith(".yml"));
+        if (files == null) return;
+        for (File f : files) {
+            String name = f.getName();
+            String lang = name.substring("aliases-".length(), name.length() - 4).toLowerCase(Locale.ROOT);
+            YamlConfiguration y = YamlConfiguration.loadConfiguration(f);
+            Map<String, Material> map = byLang.computeIfAbsent(lang, k -> new HashMap<>());
+            Map<Material, Set<String>> rev = reverse.computeIfAbsent(lang, k -> new HashMap<>());
+            for (String key : y.getKeys(false)) {
+                String matName = y.getString(key);
+                Material m = matName == null ? null : Material.matchMaterial(matName.toUpperCase(Locale.ROOT));
+                if (m != null) {
+                    String alias = key.toLowerCase(Locale.ROOT);
+                    map.put(alias, m);
+                    rev.computeIfAbsent(m, k -> new LinkedHashSet<>()).add(alias);
+                }
+            }
+        }
+    }
+
+    public Material match(String token, String lang) {
+        if (token == null) return null;
+        String t = token.toLowerCase(Locale.ROOT);
+        if (lang != null) {
+            Map<String, Material> map = byLang.get(lang.toLowerCase(Locale.ROOT));
+            if (map != null) {
+                Material m = map.get(t);
+                if (m != null) return m;
+            }
+        }
+        Map<String, Material> def = byLang.get(defaultLang);
+        if (def != null) {
+            Material m = def.get(t);
+            if (m != null) return m;
+        }
+        return null;
+    }
+
+    public Collection<String> aliases(Material m, String lang) {
+        if (m == null || lang == null) return Collections.emptySet();
+        Map<Material, Set<String>> map = reverse.get(lang.toLowerCase(Locale.ROOT));
+        if (map == null) return Collections.emptySet();
+        Set<String> set = map.get(m);
+        return set == null ? Collections.emptySet() : set;
+    }
+}

--- a/src/main/java/com/yourorg/servershop/util/Fuzzy.java
+++ b/src/main/java/com/yourorg/servershop/util/Fuzzy.java
@@ -44,12 +44,16 @@ public final class Fuzzy {
         return prev[m];
     }
 
-    public static java.util.List<Material> rankMaterials(java.util.Collection<Material> mats, String query, int limit, double threshold) {
+    public static java.util.List<Material> rankMaterials(java.util.Collection<Material> mats, String query, int limit, double threshold, com.yourorg.servershop.config.AliasManager aliases, String lang) {
         String q = normalize(query);
         java.util.List<MaterialScore> list = new java.util.ArrayList<>();
         for (Material m : mats) {
-            String name = m.name();
-            double s = similarity(q, name);
+            double s = similarity(q, m.name());
+            if (aliases != null && lang != null) {
+                for (String a : aliases.aliases(m, lang)) {
+                    s = Math.max(s, similarity(q, a));
+                }
+            }
             if (s >= threshold) list.add(new MaterialScore(m, s));
         }
         list.sort((a,b)->{
@@ -59,6 +63,10 @@ public final class Fuzzy {
         java.util.List<Material> out = new java.util.ArrayList<>();
         for (int i=0;i<list.size() && out.size()<limit;i++) out.add(list.get(i).m);
         return out;
+    }
+
+    public static java.util.List<Material> rankMaterials(java.util.Collection<Material> mats, String query, int limit, double threshold) {
+        return rankMaterials(mats, query, limit, threshold, null, null);
     }
 
     private static final class MaterialScore { final Material m; final double s; MaterialScore(Material m, double s){this.m=m;this.s=s;} }

--- a/src/main/resources/aliases-en.yml
+++ b/src/main/resources/aliases-en.yml
@@ -1,0 +1,3 @@
+# Default English aliases for item names
+stone: STONE
+cobble: COBBLESTONE

--- a/src/main/resources/aliases-es.yml
+++ b/src/main/resources/aliases-es.yml
@@ -1,0 +1,3 @@
+# Alias en Español para nombres de objetos
+piedra: STONE
+roca: COBBLESTONE

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,9 @@
 messages:
   prefix: '&6[Shop] &7'
+locale:
+  default: en
+  useClientLocale: true
+  players: {}
 weekly:
   count: 6
   discount: 0.80


### PR DESCRIPTION
## Summary
- load per-locale aliases from `aliases-<lang>.yml`
- detect player locale or per-player override to pick aliases
- use locale-aware aliases for material parsing and fuzzy search

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1114a1b14832e9ddf40925be2f7fb