### PR TITLE
Add granular reload command and alias/message support

### DIFF
--- a/src/main/java/com/yourorg/servershop/ServerShopPlugin.java
+++ b/src/main/java/com/yourorg/servershop/ServerShopPlugin.java
@@ -22,10 +22,13 @@ public final class ServerShopPlugin extends JavaPlugin {
     private ShopService shopService;
     private DynamicPricingManager dynamic;
     private CategorySettings categorySettings;
+    private Aliases aliases;
+    private org.bukkit.configuration.file.FileConfiguration messages;
 
     @Override public void onEnable() {
         saveDefaultConfig();
         saveResource("messages.yml", false);
+        saveResource("aliases.yml", false);
         saveResource("shop.yml", false);
         if (!setupEconomy()) {
             getLogger().severe("Vault economy not found. Disabling.");
@@ -34,6 +37,8 @@ public final class ServerShopPlugin extends JavaPlugin {
         }
         this.categorySettings = new CategorySettings(this);
         this.catalog = new Catalog(this); catalog.reload();
+        reloadMessages();
+        this.aliases = new Aliases(this);
         this.weekly = new WeeklyShopManager(this);
         this.logger = new LoggerManager(this);
         this.dynamic = new DynamicPricingManager(this);
@@ -79,4 +84,9 @@ public final class ServerShopPlugin extends JavaPlugin {
     public ShopService shop() { return shopService; }
     public DynamicPricingManager dynamic() { return dynamic; }
     public CategorySettings categorySettings() { return categorySettings; }
+    public Aliases aliases() { return aliases; }
+    public org.bukkit.configuration.file.FileConfiguration messages() { return messages; }
+    public void reloadMessages() { this.messages = org.bukkit.configuration.file.YamlConfiguration.loadConfiguration(new java.io.File(getDataFolder(), "messages.yml")); }
+    public void reloadAliases() { if (aliases != null) aliases.load(); else aliases = new Aliases(this); }
+    public String msg(String key) { return messages.getString(key, key); }
 }

--- a/src/main/java/com/yourorg/servershop/commands/AdminCommand.java
+++ b/src/main/java/com/yourorg/servershop/commands/AdminCommand.java
@@ -17,7 +17,7 @@ public final class AdminCommand {
         switch (args[1].toLowerCase()) {
             case "category": return handleCategory(sender, slice(args, 2));
             case "import": return handleImport(sender);
-            case "reload": plugin.reloadConfig(); plugin.catalog().reload(); sender.sendMessage(plugin.prefixed("Reloaded.")); return true;
+            case "reload": return handleReload(sender, slice(args, 2));
             default: help(sender); return true;
         }
     }
@@ -69,6 +69,36 @@ public final class AdminCommand {
     }
 
     private static String[] slice(String[] a, int from) { String[] b = new String[Math.max(0, a.length-from)]; System.arraycopy(a, from, b, 0, b.length); return b; }
-    private void help(CommandSender s) { s.sendMessage(plugin.prefixed("/shop admin category <list|setmult|toggle> ... | import | reload")); }
+    private boolean handleReload(CommandSender sender, String[] args) {
+        String what = args.length < 1 ? "all" : args[0].toLowerCase();
+        switch (what) {
+            case "all":
+                plugin.reloadConfig();
+                plugin.catalog().reload();
+                plugin.categorySettings().load();
+                plugin.reloadMessages();
+                plugin.reloadAliases();
+                sender.sendMessage(plugin.prefixed("Reloaded all."));
+                return true;
+            case "config":
+                plugin.reloadConfig();
+                plugin.catalog().reload();
+                sender.sendMessage(plugin.prefixed("Reloaded config."));
+                return true;
+            case "categories":
+                plugin.categorySettings().load();
+                sender.sendMessage(plugin.prefixed("Reloaded categories."));
+                return true;
+            case "messages":
+                plugin.reloadMessages();
+                plugin.reloadAliases();
+                sender.sendMessage(plugin.prefixed("Reloaded messages and aliases."));
+                return true;
+            default:
+                sender.sendMessage(plugin.prefixed("Usage: /shop admin reload <all|config|categories|messages>"));
+                return true;
+        }
+    }
+    private void help(CommandSender s) { s.sendMessage(plugin.prefixed("/shop admin category <list|setmult|toggle> ... | import | reload <all|config|categories|messages>")); }
     private void helpCategory(CommandSender s) { s.sendMessage(plugin.prefixed("/shop admin category list | setmult <cat> <x> | toggle <cat> <on|off>")); }
 }

--- a/src/main/java/com/yourorg/servershop/commands/SellAllCommand.java
+++ b/src/main/java/com/yourorg/servershop/commands/SellAllCommand.java
@@ -9,7 +9,7 @@ public final class SellAllCommand implements CommandExecutor {
     public SellAllCommand(ServerShopPlugin plugin) { this.plugin = plugin; }
 
     @Override public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
-        if (!(sender instanceof Player p)) { sender.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.not-a-player"))); return true; }
+        if (!(sender instanceof Player p)) { sender.sendMessage(plugin.prefixed(plugin.msg("not-a-player"))); return true; }
         plugin.menus().openSell(p);
         return true;
     }

--- a/src/main/java/com/yourorg/servershop/commands/SellCommand.java
+++ b/src/main/java/com/yourorg/servershop/commands/SellCommand.java
@@ -10,11 +10,11 @@ public final class SellCommand implements CommandExecutor {
     public SellCommand(ServerShopPlugin plugin) { this.plugin = plugin; }
 
     @Override public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
-        if (!(sender instanceof Player p)) { sender.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.not-a-player"))); return true; }
+        if (!(sender instanceof Player p)) { sender.sendMessage(plugin.prefixed(plugin.msg("not-a-player"))); return true; }
         if (args.length < 2) { p.sendMessage(plugin.prefixed("/sell <material> <qty>")); return true; }
-        Material mat = Util.parseMaterial(args[1]);
+        Material mat = Util.parseMaterial(plugin, args[1]);
         int qty; try { qty = Math.max(1, Integer.parseInt(args.length > 2 ? args[2] : "1")); } catch (Exception e) { qty = 1; }
-        if (mat == null) { p.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.unknown-material").replace("%material%", args[1]))); return true; }
+        if (mat == null) { p.sendMessage(plugin.prefixed(plugin.msg("unknown-material").replace("%material%", args[1]))); return true; }
         plugin.shop().sell(p, mat, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
         return true;
     }

--- a/src/main/java/com/yourorg/servershop/commands/ShopCommand.java
+++ b/src/main/java/com/yourorg/servershop/commands/ShopCommand.java
@@ -18,7 +18,7 @@ public final class ShopCommand implements TabExecutor {
 
     @Override public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
         if (args.length == 0) {
-            if (sender instanceof Player p) { plugin.menus().openCategories(p); } else sender.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.not-a-player")));
+            if (sender instanceof Player p) { plugin.menus().openCategories(p); } else sender.sendMessage(plugin.prefixed(plugin.msg("not-a-player")));
             return true;
         }
         if (args[0].equalsIgnoreCase("admin")) return admin.handle(sender, args);
@@ -60,7 +60,7 @@ public final class ShopCommand implements TabExecutor {
 
     private boolean price(CommandSender sender, String[] args) {
         if (args.length < 2) { sender.sendMessage(plugin.prefixed("/shop price <material>")); return true; }
-        Material mat = Util.parseMaterial(args[1]);
+        Material mat = Util.parseMaterial(plugin, args[1]);
         if (mat == null) { sender.sendMessage(plugin.prefixed(msg("unknown-material").replace("%material%", args[1]))); return true; }
         Optional<ItemEntry> opt = plugin.catalog().get(mat);
         if (opt.isEmpty() || !opt.get().canBuy()) { sender.sendMessage(plugin.prefixed(msg("not-for-sale").replace("%material%", mat.name()))); return true; }
@@ -73,14 +73,14 @@ public final class ShopCommand implements TabExecutor {
         if (!(sender instanceof Player p)) { sender.sendMessage(plugin.prefixed(msg("not-a-player"))); return true; }
         if (plugin.economy() == null) { sender.sendMessage(plugin.prefixed(msg("no-economy"))); return true; }
         if (args.length < 3) { p.sendMessage(plugin.prefixed("/shop buy <material> <qty>")); return true; }
-        Material mat = Util.parseMaterial(args[1]);
+        Material mat = Util.parseMaterial(plugin, args[1]);
         int qty; try { qty = Math.max(1, Integer.parseInt(args[2])); } catch (Exception ex) { qty = 1; }
         if (mat == null) { p.sendMessage(plugin.prefixed(msg("unknown-material").replace("%material%", args[1]))); return true; }
         plugin.shop().buy(p, mat, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
         return true;
     }
 
-    private String msg(String key) { return plugin.getConfig().getString("messages." + key, key); }
+    private String msg(String key) { return plugin.msg(key); }
 
     @Override public java.util.List<String> onTabComplete(CommandSender sender, Command cmd, String alias, String[] args) {
         java.util.List<String> out = new java.util.ArrayList<>();
@@ -97,6 +97,9 @@ public final class ShopCommand implements TabExecutor {
                     if (args.length == 4) { suggestCats(out, args[3]); return out; }
                     if (args.length == 5) { suggest(out, args[4], "on","off"); return out; }
                 }
+            }
+            if (args[1].equalsIgnoreCase("reload")) {
+                if (args.length == 3) { suggest(out, args[2], "all","config","categories","messages"); return out; }
             }
             return out;
         }

--- a/src/main/java/com/yourorg/servershop/commands/ShopLogCommand.java
+++ b/src/main/java/com/yourorg/servershop/commands/ShopLogCommand.java
@@ -19,9 +19,9 @@ public final class ShopLogCommand implements CommandExecutor {
         if (args.length >= 2) try { limit = Integer.parseInt(args[1]); } catch (Exception ignored) {}
         final int flimit = limit; final String fplayer = player;
         plugin.logger().lastAsync(fplayer, flimit, list -> {
-            sender.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.log-header").replace("%n%", String.valueOf(flimit))));
+            sender.sendMessage(plugin.prefixed(plugin.msg("log-header").replace("%n%", String.valueOf(flimit))));
             for (Transaction t : list) {
-                String line = plugin.getConfig().getString("messages.log-line");
+                String line = plugin.msg("log-line");
                 line = line.replace("%time%", fmt.format(t.time))
                         .replace("%player%", t.player)
                         .replace("%type%", t.type.name().toLowerCase())

--- a/src/main/java/com/yourorg/servershop/commands/Util.java
+++ b/src/main/java/com/yourorg/servershop/commands/Util.java
@@ -1,10 +1,13 @@
 package com.yourorg.servershop.commands;
 
+import com.yourorg.servershop.ServerShopPlugin;
 import org.bukkit.Material;
 
 public final class Util {
-    public static Material parseMaterial(String raw) {
+    public static Material parseMaterial(ServerShopPlugin plugin, String raw) {
         if (raw == null) return null;
+        Material aliased = plugin.aliases().resolve(raw);
+        if (aliased != null) return aliased;
         return Material.matchMaterial(raw.toUpperCase().replace('-', '_').replace(' ', '_'));
     }
 }

--- a/src/main/java/com/yourorg/servershop/config/Aliases.java
+++ b/src/main/java/com/yourorg/servershop/config/Aliases.java
@@ -1,0 +1,38 @@
+package com.yourorg.servershop.config;
+
+import com.yourorg.servershop.ServerShopPlugin;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public final class Aliases {
+    private final ServerShopPlugin plugin;
+    private final File file;
+    private final Map<String, Material> map = new HashMap<>();
+
+    public Aliases(ServerShopPlugin plugin) {
+        this.plugin = plugin;
+        this.file = new File(plugin.getDataFolder(), "aliases.yml");
+        load();
+    }
+
+    public synchronized void load() {
+        map.clear();
+        YamlConfiguration y = YamlConfiguration.loadConfiguration(file);
+        for (String key : y.getKeys(false)) {
+            String val = y.getString(key);
+            if (val == null) continue;
+            Material m = Material.matchMaterial(val.toUpperCase(Locale.ROOT));
+            if (m != null) map.put(key.toLowerCase(Locale.ROOT), m);
+        }
+    }
+
+    public synchronized Material resolve(String alias) {
+        if (alias == null) return null;
+        return map.get(alias.toLowerCase(Locale.ROOT));
+    }
+}

--- a/src/main/java/com/yourorg/servershop/gui/SellMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/SellMenu.java
@@ -66,7 +66,7 @@ public final class SellMenu implements MenuView {
             // TODO: consider calling plugin.dynamic().adjustOnSell(m, qty) per TODO list
         }
         if (total > 0) plugin.economy().depositPlayer(p, total);
-        p.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.soldall").replace("%count%", String.valueOf(stacks)).replace("%total%", String.format("%.2f", total))));
+        p.sendMessage(plugin.prefixed(plugin.msg("soldall").replace("%count%", String.valueOf(stacks)).replace("%total%", String.format("%.2f", total))));
         refresh(p);
     }
 

--- a/src/main/java/com/yourorg/servershop/shop/ShopService.java
+++ b/src/main/java/com/yourorg/servershop/shop/ShopService.java
@@ -78,5 +78,5 @@ public final class ShopService {
     }
 
     private static String fmt(double v) { return String.format("%.2f", v); }
-    private String msg(String key) { return plugin.getConfig().getString("messages." + key, key); }
+    private String msg(String key) { return plugin.msg(key); }
 }

--- a/src/main/resources/aliases.yml
+++ b/src/main/resources/aliases.yml
@@ -1,0 +1,2 @@
+# alias -> material name
+cobble: COBBLESTONE


### PR DESCRIPTION
## Summary
- Add `Aliases` config and load messages/aliases on startup
- Implement `/shop admin reload <all|config|categories|messages>`
- Use alias map when parsing materials

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a111579204832ead84888e3b64db13