### PR TITLE
Add importer tests for invalid and disallowed materials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,18 @@
       <artifactId>mysql-connector-j</artifactId>
       <version>8.4.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.seeseemelk</groupId>
+      <artifactId>MockBukkit-v1.20</artifactId>
+      <version>3.93.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -79,6 +91,14 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+        <configuration>
+          <useModulePath>false</useModulePath>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/test/java/com/yourorg/servershop/importer/ShopImporterTest.java
+++ b/src/test/java/com/yourorg/servershop/importer/ShopImporterTest.java
@@ -1,0 +1,75 @@
+package com.yourorg.servershop.importer;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import com.yourorg.servershop.ServerShopPlugin;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ShopImporterTest {
+    private ServerShopPlugin plugin;
+
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+        plugin = MockBukkit.load(ServerShopPlugin.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void badMaterialNamesIgnored() throws Exception {
+        File imports = createImportDir("NO_SUCH_MATERIAL");
+        int result = new ShopImporter(plugin).importFrom(imports);
+
+        assertTrue(result > 0, "Importer should process valid materials");
+        YamlConfiguration out = YamlConfiguration.loadConfiguration(new File(plugin.getDataFolder(), "shop.yml"));
+        assertTrue(out.contains("categories.test.STONE.buy"), "Valid material should be imported");
+        assertFalse(out.contains("categories.test.NO_SUCH_MATERIAL"), "Invalid material should be ignored");
+    }
+
+    @Test
+    void disallowedMaterialsExcluded() throws Exception {
+        File imports = createImportDir("DIAMOND_SWORD");
+        int result = new ShopImporter(plugin).importFrom(imports);
+
+        assertTrue(result > 0, "Importer should process valid materials");
+        YamlConfiguration out = YamlConfiguration.loadConfiguration(new File(plugin.getDataFolder(), "shop.yml"));
+        assertTrue(out.contains("categories.test.STONE.buy"), "Valid material should be imported");
+        assertFalse(out.contains("categories.test.DIAMOND_SWORD"), "Disallowed material should be excluded");
+    }
+
+    private File createImportDir(String secondMaterial) throws IOException {
+        Path root = Files.createTempDirectory("imports");
+        Path shops = root.resolve("shops");
+        Files.createDirectory(shops);
+
+        String yaml = ""
+                + "items:\n"
+                + "  entry:\n"
+                + "    buy-prices:\n"
+                + "      '1':\n"
+                + "        amount: '$10'\n"
+                + "    sell-prices:\n"
+                + "      '1':\n"
+                + "        amount: '$5'\n"
+                + "    products:\n"
+                + "      '1':\n"
+                + "        material: STONE\n"
+                + "      '2':\n"
+                + "        material: " + secondMaterial + "\n";
+        Files.writeString(shops.resolve("test.yml"), yaml);
+        return root.toFile();
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit and MockBukkit test dependencies
- create ShopImporter tests ensuring bad material names and disallowed materials are ignored

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a1116250c4832eaeffe34921646390