### PR TITLE
Add bStats metrics tracking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
       <artifactId>mysql-connector-j</artifactId>
       <version>8.4.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.bstats</groupId>
+      <artifactId>bstats-bukkit</artifactId>
+      <version>3.0.2</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/yourorg/servershop/ServerShopPlugin.java
+++ b/src/main/java/com/yourorg/servershop/ServerShopPlugin.java
@@ -7,6 +7,7 @@ import com.yourorg.servershop.shop.*;
 import com.yourorg.servershop.weekly.*;
 import com.yourorg.servershop.dynamic.*;
 import com.yourorg.servershop.config.*;
+import com.yourorg.servershop.metrics.MetricsManager;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -22,6 +23,7 @@ public final class ServerShopPlugin extends JavaPlugin {
     private ShopService shopService;
     private DynamicPricingManager dynamic;
     private CategorySettings categorySettings;
+    private MetricsManager metrics;
 
     @Override public void onEnable() {
         saveDefaultConfig();
@@ -40,6 +42,10 @@ public final class ServerShopPlugin extends JavaPlugin {
         this.shopService = new ShopService(this);
         this.menus = new MenuManager(this);
         Bukkit.getPluginManager().registerEvents(menus, this);
+
+        if (getConfig().getBoolean("metrics.enabled", true)) {
+            this.metrics = new MetricsManager(this);
+        }
 
         int saveEvery = Math.max(1, getConfig().getInt("dynamicPricing.decay.saveEveryMinutes", 5));
         Bukkit.getScheduler().runTaskTimerAsynchronously(this, dynamic::tickSaveAll, 20L * 60L * saveEvery, 20L * 60L * saveEvery);
@@ -79,4 +85,5 @@ public final class ServerShopPlugin extends JavaPlugin {
     public ShopService shop() { return shopService; }
     public DynamicPricingManager dynamic() { return dynamic; }
     public CategorySettings categorySettings() { return categorySettings; }
+    public MetricsManager metrics() { return metrics; }
 }

--- a/src/main/java/com/yourorg/servershop/metrics/MetricsManager.java
+++ b/src/main/java/com/yourorg/servershop/metrics/MetricsManager.java
@@ -1,0 +1,65 @@
+package com.yourorg.servershop.metrics;
+
+import com.yourorg.servershop.ServerShopPlugin;
+import org.bstats.bukkit.Metrics;
+import org.bstats.charts.AdvancedPie;
+import org.bstats.charts.SimplePie;
+import org.bstats.charts.SingleLineChart;
+import org.bukkit.Material;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Handles bStats metrics for the plugin.
+ */
+public final class MetricsManager {
+    private static final int BSTATS_PLUGIN_ID = 21312; // TODO: replace with your bStats plugin id
+
+    private final Metrics metrics;
+    private int buys;
+    private int sells;
+    private double totalValue;
+    private int transactions;
+    private final Map<Material, Integer> itemUsage = new ConcurrentHashMap<>();
+
+    public MetricsManager(ServerShopPlugin plugin) {
+        this.metrics = new Metrics(plugin, BSTATS_PLUGIN_ID);
+        metrics.addCustomChart(new SingleLineChart("buys", () -> buys));
+        metrics.addCustomChart(new SingleLineChart("sells", () -> sells));
+        metrics.addCustomChart(new AdvancedPie("top_10_items", this::top10Items));
+        metrics.addCustomChart(new SingleLineChart("avg_transaction_value", this::averageValue));
+        metrics.addCustomChart(new SimplePie("economy_provider", () -> plugin.economy().getName()));
+    }
+
+    public void recordBuy(Material mat, double total) {
+        buys++;
+        record(mat, total);
+    }
+
+    public void recordSell(Material mat, double total) {
+        sells++;
+        record(mat, total);
+    }
+
+    private void record(Material mat, double total) {
+        itemUsage.merge(mat, 1, Integer::sum);
+        totalValue += total;
+        transactions++;
+    }
+
+    private Map<String, Integer> top10Items() {
+        return itemUsage.entrySet().stream()
+                .sorted(Map.Entry.<Material, Integer>comparingByValue().reversed())
+                .limit(10)
+                .collect(Collectors.toMap(e -> e.getKey().name(), Map.Entry::getValue, (a, b) -> a, LinkedHashMap::new));
+    }
+
+    private int averageValue() {
+        if (transactions == 0) return 0;
+        return (int) Math.round(totalValue / transactions);
+    }
+}
+

--- a/src/main/java/com/yourorg/servershop/shop/ShopService.java
+++ b/src/main/java/com/yourorg/servershop/shop/ShopService.java
@@ -33,6 +33,9 @@ public final class ShopService {
         if (!left.isEmpty()) { econ.depositPlayer(p, total); return Optional.of("Inventory full."); }
         plugin.dynamic().adjustOnBuy(mat, qty);
         plugin.logger().logAsync(new Transaction(Instant.now(), p.getName(), Transaction.Type.BUY, mat, qty, total));
+        if (plugin.metrics() != null) {
+            plugin.metrics().recordBuy(mat, total);
+        }
         p.sendMessage(plugin.prefixed(msg("purchased").replace("%qty%", String.valueOf(qty)).replace("%material%", mat.name()).replace("%price%", fmt(total))));
         return Optional.empty();
     }
@@ -49,6 +52,9 @@ public final class ShopService {
         plugin.economy().depositPlayer(p, total);
         plugin.dynamic().adjustOnSell(mat, removed);
         plugin.logger().logAsync(new Transaction(Instant.now(), p.getName(), Transaction.Type.SELL, mat, removed, total));
+        if (plugin.metrics() != null) {
+            plugin.metrics().recordSell(mat, total);
+        }
         p.sendMessage(plugin.prefixed(msg("sold").replace("%qty%", String.valueOf(removed)).replace("%material%", mat.name()).replace("%price%", fmt(total))));
         return Optional.empty();
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,5 @@
+metrics:
+  enabled: true
 messages:
   prefix: '&6[Shop] &7'
 weekly:


### PR DESCRIPTION
## Summary
- add bStats dependency and config toggle
- introduce MetricsManager for buy/sell stats, top items, average transaction value and economy provider
- hook metrics recording into shop actions guarded by config

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a11169d3c4832eb8f5b9c1d2b12e64