### PR TITLE
Relocate shaded dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
       <artifactId>mysql-connector-j</artifactId>
       <version>8.4.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.bstats</groupId>
+      <artifactId>bstats-bukkit</artifactId>
+      <version>3.0.2</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -75,7 +80,27 @@
             <goals><goal>shade</goal></goals>
             <configuration>
               <minimizeJar>false</minimizeJar>
-              <relocations/>
+              <relocations>
+                <relocation>
+                  <pattern>org.bstats</pattern>
+                  <shadedPattern>com.yourorg.servershop.libs.bstats</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.zaxxer.hikari</pattern>
+                  <shadedPattern>com.yourorg.servershop.libs.hikari</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.mysql.cj</pattern>
+                  <shadedPattern>com.yourorg.servershop.libs.mysql.cj</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.slf4j</pattern>
+                  <shadedPattern>com.yourorg.servershop.libs.slf4j</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/com/yourorg/servershop/ServerShopPlugin.java
+++ b/src/main/java/com/yourorg/servershop/ServerShopPlugin.java
@@ -12,6 +12,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bstats.bukkit.Metrics;
 
 public final class ServerShopPlugin extends JavaPlugin {
     private Economy economy;
@@ -49,6 +50,7 @@ public final class ServerShopPlugin extends JavaPlugin {
         getCommand("sellall").setExecutor(new SellAllCommand(this));
         getCommand("shoplog").setExecutor(new ShopLogCommand(this));
         getCommand("weeklyshop").setExecutor(new WeeklyShopCommand(this));
+        new Metrics(this, 21916);
         getLogger().info("DynamicServerShop enabled (Importer + Admin + Category multipliers + Fuzzy Search).");
     }
 


### PR DESCRIPTION
## Summary
- Add bStats metrics and relocate all shaded dependencies to internal namespaces
- Configure Maven Shade plugin to relocate HikariCP, MySQL driver and SLF4J
- Initialize bStats metrics on plugin startup

## Testing
- `mvn -q -e -B package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a111722848832e8c990e20bfc0cf8f