### PR TITLE
Add async YAML write queue with periodic flush

### DIFF
--- a/src/main/java/com/yourorg/servershop/ServerShopPlugin.java
+++ b/src/main/java/com/yourorg/servershop/ServerShopPlugin.java
@@ -53,8 +53,8 @@ public final class ServerShopPlugin extends JavaPlugin {
     }
 
     @Override public void onDisable() {
-        if (logger != null) logger.close();
-        if (dynamic != null) dynamic.close();
+        if (logger != null) { logger.flush(); logger.close(); }
+        if (dynamic != null) { dynamic.flush(); dynamic.close(); }
     }
 
     private boolean setupEconomy() {

--- a/src/main/java/com/yourorg/servershop/dynamic/PriceStorage.java
+++ b/src/main/java/com/yourorg/servershop/dynamic/PriceStorage.java
@@ -6,5 +6,6 @@ public interface PriceStorage {
     java.util.Map<Material, PriceState> loadAll() throws Exception;
     void save(Material material, PriceState state) throws Exception;
     void saveAll(java.util.Map<Material, PriceState> map) throws Exception;
+    void flush() throws Exception;
     void close() throws Exception;
 }

--- a/src/main/java/com/yourorg/servershop/dynamic/SQLPriceStorage.java
+++ b/src/main/java/com/yourorg/servershop/dynamic/SQLPriceStorage.java
@@ -69,5 +69,7 @@ public final class SQLPriceStorage implements PriceStorage {
         }
     }
 
+    @Override public void flush() { }
+
     @Override public void close() { if (ds != null) ds.close(); }
 }

--- a/src/main/java/com/yourorg/servershop/dynamic/YAMLPriceStorage.java
+++ b/src/main/java/com/yourorg/servershop/dynamic/YAMLPriceStorage.java
@@ -1,23 +1,40 @@
 package com.yourorg.servershop.dynamic;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 
+/**
+ * Price storage backed by a YAML file. Updates are queued in memory and
+ * flushed to disk periodically by an async task. This avoids frequent disk IO
+ * while still ensuring data is written on shutdown.
+ */
 public final class YAMLPriceStorage implements PriceStorage {
+    private final JavaPlugin plugin;
     private final File file;
+    private final java.util.Map<Material, PriceState> pending = new java.util.EnumMap<>(Material.class);
+    private final int taskId;
 
-    public YAMLPriceStorage(File dataFolder) { this.file = new File(dataFolder, "prices.yml"); }
+    public YAMLPriceStorage(JavaPlugin plugin, long flushSeconds) {
+        this.plugin = plugin;
+        this.file = new File(plugin.getDataFolder(), "prices.yml");
+        long ticks = Math.max(1L, flushSeconds) * 20L;
+        this.taskId = Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, this::flush, ticks, ticks).getTaskId();
+    }
 
-    @Override public synchronized java.util.Map<Material, PriceState> loadAll() {
+    @Override
+    public synchronized java.util.Map<Material, PriceState> loadAll() {
         YamlConfiguration y = YamlConfiguration.loadConfiguration(file);
         java.util.Map<Material, PriceState> map = new java.util.EnumMap<>(Material.class);
         ConfigurationSection sec = y.getConfigurationSection("prices");
         if (sec == null) return map;
         for (String key : sec.getKeys(false)) {
-            Material m = Material.matchMaterial(key); if (m == null) continue;
+            Material m = Material.matchMaterial(key);
+            if (m == null) continue;
             double mult = sec.getConfigurationSection(key).getDouble("multiplier", 1.0);
             long last = sec.getConfigurationSection(key).getLong("lastUpdate", System.currentTimeMillis());
             map.put(m, new PriceState(mult, last));
@@ -25,21 +42,37 @@ public final class YAMLPriceStorage implements PriceStorage {
         return map;
     }
 
-    @Override public synchronized void save(Material mat, PriceState st) throws Exception {
-        YamlConfiguration y = YamlConfiguration.loadConfiguration(file);
-        y.set("prices."+mat.name()+".multiplier", st.multiplier);
-        y.set("prices."+mat.name()+".lastUpdate", st.lastUpdateMs);
-        y.save(file);
+    @Override
+    public synchronized void save(Material mat, PriceState st) {
+        pending.put(mat, st);
     }
 
-    @Override public synchronized void saveAll(java.util.Map<Material, PriceState> map) throws Exception {
+    @Override
+    public synchronized void saveAll(java.util.Map<Material, PriceState> map) {
+        pending.putAll(map);
+        flush();
+    }
+
+    @Override
+    public synchronized void flush() {
+        if (pending.isEmpty()) return;
         YamlConfiguration y = YamlConfiguration.loadConfiguration(file);
-        for (var e : map.entrySet()) {
-            y.set("prices."+e.getKey().name()+".multiplier", e.getValue().multiplier);
-            y.set("prices."+e.getKey().name()+".lastUpdate", e.getValue().lastUpdateMs);
+        for (var e : pending.entrySet()) {
+            y.set("prices." + e.getKey().name() + ".multiplier", e.getValue().multiplier);
+            y.set("prices." + e.getKey().name() + ".lastUpdate", e.getValue().lastUpdateMs);
         }
-        y.save(file);
+        pending.clear();
+        try {
+            y.save(file);
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to save prices: " + e.getMessage());
+        }
     }
 
-    @Override public void close() { }
+    @Override
+    public synchronized void close() {
+        Bukkit.getScheduler().cancelTask(taskId);
+        flush();
+    }
 }
+

--- a/src/main/java/com/yourorg/servershop/logging/LogStorage.java
+++ b/src/main/java/com/yourorg/servershop/logging/LogStorage.java
@@ -4,5 +4,6 @@ public interface LogStorage {
     void append(Transaction tx) throws Exception;
     java.util.List<Transaction> last(int limit) throws Exception;
     java.util.List<Transaction> lastOf(String player, int limit) throws Exception;
+    void flush() throws Exception;
     void close() throws Exception;
 }

--- a/src/main/java/com/yourorg/servershop/logging/LoggerManager.java
+++ b/src/main/java/com/yourorg/servershop/logging/LoggerManager.java
@@ -13,6 +13,7 @@ public final class LoggerManager {
         this.plugin = plugin;
         var c = plugin.getConfig();
         String mode = c.getString("logging.storage", "YAML").toUpperCase();
+        long flushSec = c.getLong("yaml.flushEverySeconds", 5L);
         LogStorage s;
         if ("MYSQL".equals(mode)) {
             try {
@@ -32,11 +33,11 @@ public final class LoggerManager {
             } catch (Exception e) {
                 plugin.getLogger().warning("MySQL setup failed, falling back to YAML: " + e.getMessage());
                 int max = c.getInt("logging.maxEntries", 1000);
-                s = new YAMLLogStorage(plugin.getDataFolder(), max);
+                s = new YAMLLogStorage(plugin, max, flushSec);
             }
         } else {
             int max = c.getInt("logging.maxEntries", 1000);
-            s = new YAMLLogStorage(plugin.getDataFolder(), max);
+            s = new YAMLLogStorage(plugin, max, flushSec);
             plugin.getLogger().info("Logging storage: YAML");
         }
         this.storage = s;
@@ -47,6 +48,8 @@ public final class LoggerManager {
             try { storage.append(tx); } catch (Exception e) { plugin.getLogger().warning("Failed to log: " + e.getMessage()); }
         });
     }
+
+    public void flush() { try { storage.flush(); } catch (Exception ignored) { } }
 
     public void close() { try { storage.close(); } catch (Exception ignored) { } }
 

--- a/src/main/java/com/yourorg/servershop/logging/SQLLogStorage.java
+++ b/src/main/java/com/yourorg/servershop/logging/SQLLogStorage.java
@@ -51,6 +51,7 @@ public final class SQLLogStorage implements LogStorage {
 
     @Override public java.util.List<Transaction> last(int limit) throws Exception { return query(null, limit); }
     @Override public java.util.List<Transaction> lastOf(String player, int limit) throws Exception { return query(player, limit); }
+    @Override public void flush() { }
     @Override public void close() { if (ds != null) ds.close(); }
 
     private java.util.List<Transaction> query(String player, int limit) throws Exception {


### PR DESCRIPTION
## Summary
- Batch YAML price writes using an async queue that flushes on a timer
- Queue log transactions and flush them periodically to reduce I/O
- Flush queued data on plugin disable to prevent loss

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a111e31390832ea3b211aea7b166c5