### PR TITLE
Validate category multiplier input for admin command

### DIFF
--- a/src/main/java/com/yourorg/servershop/commands/AdminCommand.java
+++ b/src/main/java/com/yourorg/servershop/commands/AdminCommand.java
@@ -53,9 +53,18 @@ public final class AdminCommand {
         if (sub.equals("setmult") && args.length >= 3) {
             String cat = args[1];
             double m;
-            try { m = Double.parseDouble(args[2]); } catch (Exception e) { sender.sendMessage(plugin.prefixed("Bad number.")); return true; }
+            try {
+                m = Double.parseDouble(args[2]);
+            } catch (Exception e) {
+                sender.sendMessage(plugin.prefixed("Multiplier must be a number between 0.0 and 10.0."));
+                return true;
+            }
+            if (Double.isNaN(m) || Double.isInfinite(m) || m < 0.0 || m > 10.0) {
+                sender.sendMessage(plugin.prefixed("Multiplier must be between 0.0 and 10.0."));
+                return true;
+            }
             plugin.categorySettings().setMultiplier(cat, m);
-            sender.sendMessage(plugin.prefixed("Set multiplier for "+cat+" to x"+m));
+            sender.sendMessage(plugin.prefixed("Set multiplier for " + cat + " to x" + m));
             return true;
         }
         if (sub.equals("toggle") && args.length >= 3) {

--- a/src/main/java/com/yourorg/servershop/config/CategorySettings.java
+++ b/src/main/java/com/yourorg/servershop/config/CategorySettings.java
@@ -27,7 +27,12 @@ public final class CategorySettings {
     public synchronized boolean isEnabled(String name) { Entry e = map.get(name); return e == null ? true : e.enabled; }
     public synchronized double multiplier(String name) { Entry e = map.get(name); return e == null ? 1.0 : e.multiplier; }
     public synchronized void setEnabled(String name, boolean on) { ensureCategory(name); map.get(name).enabled = on; save(); }
-    public synchronized void setMultiplier(String name, double m) { ensureCategory(name); map.get(name).multiplier = Math.max(0.0, m); save(); }
+    public synchronized void setMultiplier(String name, double m) {
+        ensureCategory(name);
+        if (Double.isNaN(m) || Double.isInfinite(m)) return;
+        map.get(name).multiplier = Math.max(0.0, Math.min(10.0, m));
+        save();
+    }
     public synchronized Set<String> categories() { return new LinkedHashSet<>(map.keySet()); }
 
     public synchronized void load() {


### PR DESCRIPTION
## Summary
- require numeric multiplier between 0.0 and 10.0 for `/shop admin category setmult`
- clamp category multipliers to this range and ignore non-finite values

## Testing
- `mvn -q -e test` *(fails: Plugin resolution error: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a111efd1d0832e9d64a944ccfb76b2