### PR TITLE
Graceful handling when Vault is missing

### DIFF
--- a/src/main/java/com/yourorg/servershop/ServerShopPlugin.java
+++ b/src/main/java/com/yourorg/servershop/ServerShopPlugin.java
@@ -28,9 +28,7 @@ public final class ServerShopPlugin extends JavaPlugin {
         saveResource("messages.yml", false);
         saveResource("shop.yml", false);
         if (!setupEconomy()) {
-            getLogger().severe("Vault economy not found. Disabling.");
-            Bukkit.getPluginManager().disablePlugin(this);
-            return;
+            getLogger().warning("Vault economy not found. Buy/Sell disabled.");
         }
         this.categorySettings = new CategorySettings(this);
         this.catalog = new Catalog(this); catalog.reload();

--- a/src/main/java/com/yourorg/servershop/commands/SellAllCommand.java
+++ b/src/main/java/com/yourorg/servershop/commands/SellAllCommand.java
@@ -10,6 +10,7 @@ public final class SellAllCommand implements CommandExecutor {
 
     @Override public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
         if (!(sender instanceof Player p)) { sender.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.not-a-player"))); return true; }
+        if (plugin.economy() == null) { p.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.no-economy"))); return true; }
         plugin.menus().openSell(p);
         return true;
     }

--- a/src/main/java/com/yourorg/servershop/commands/SellCommand.java
+++ b/src/main/java/com/yourorg/servershop/commands/SellCommand.java
@@ -11,6 +11,7 @@ public final class SellCommand implements CommandExecutor {
 
     @Override public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
         if (!(sender instanceof Player p)) { sender.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.not-a-player"))); return true; }
+        if (plugin.economy() == null) { p.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.no-economy"))); return true; }
         if (args.length < 2) { p.sendMessage(plugin.prefixed("/sell <material> <qty>")); return true; }
         Material mat = Util.parseMaterial(args[1]);
         int qty; try { qty = Math.max(1, Integer.parseInt(args.length > 2 ? args[2] : "1")); } catch (Exception e) { qty = 1; }

--- a/src/main/java/com/yourorg/servershop/gui/ItemsMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/ItemsMenu.java
@@ -44,6 +44,10 @@ public final class ItemsMenu implements MenuView {
             p.sendMessage(plugin.prefixed(m.name()+": $"+String.format("%.2f", buy)));
             return;
         }
+        if (plugin.economy() == null) {
+            p.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.no-economy")));
+            return;
+        }
         int qty = e.isShiftClick() ? 16 : 1;
         plugin.shop().buy(p, m, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
     }

--- a/src/main/java/com/yourorg/servershop/gui/MenuManager.java
+++ b/src/main/java/com/yourorg/servershop/gui/MenuManager.java
@@ -17,7 +17,13 @@ public final class MenuManager implements Listener {
     public void openCategories(Player p) { open(p, new CategoryMenu(plugin)); }
     public void openItems(Player p, String category) { open(p, new ItemsMenu(plugin, category)); }
     public void openWeekly(Player p) { if (p!=null) open(p, new WeeklyMenu(plugin)); }
-    public void openSell(Player p) { open(p, new SellMenu(plugin)); }
+    public void openSell(Player p) {
+        if (plugin.economy() == null) {
+            p.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.no-economy")));
+            return;
+        }
+        open(p, new SellMenu(plugin));
+    }
     public void openSearch(Player p, String query, java.util.List<org.bukkit.Material> results) { open(p, new SearchMenu(plugin, query, results, 0)); }
     public void openSearch(Player p, String query, java.util.List<org.bukkit.Material> results, int page) { open(p, new SearchMenu(plugin, query, results, page)); }
 

--- a/src/main/java/com/yourorg/servershop/gui/SearchMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/SearchMenu.java
@@ -52,6 +52,7 @@ public final class SearchMenu implements MenuView {
         var m = org.bukkit.Material.matchMaterial(org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName()));
         if (m == null) return;
         if (e.isRightClick()) { double buy = plugin.shop().priceBuy(m); p.sendMessage(plugin.prefixed(m.name()+": $"+String.format("%.2f", buy))); return; }
+        if (plugin.economy() == null) { p.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.no-economy"))); return; }
         int qty = e.isShiftClick() ? 16 : 1;
         plugin.shop().buy(p, m, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
     }

--- a/src/main/java/com/yourorg/servershop/gui/SellMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/SellMenu.java
@@ -22,6 +22,7 @@ public final class SellMenu implements MenuView {
         if (!(e.getWhoClicked() instanceof Player p)) return;
         var it = e.getCurrentItem(); if (it == null) return;
         var m = it.getType(); if (m == Material.AIR) return;
+        if (plugin.economy() == null) { p.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.no-economy"))); return; }
         if (it.getItemMeta() != null && org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName()).equalsIgnoreCase("Sell All")) {
             sellAll(p); return;
         }
@@ -52,6 +53,7 @@ public final class SellMenu implements MenuView {
     }
 
     private void sellAll(Player p) {
+        if (plugin.economy() == null) { p.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.no-economy"))); return; }
         double total = 0.0; int stacks = 0;
         for (int i = 0; i < p.getInventory().getSize(); i++) {
             ItemStack s = p.getInventory().getItem(i);

--- a/src/main/java/com/yourorg/servershop/gui/WeeklyMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/WeeklyMenu.java
@@ -29,6 +29,7 @@ public final class WeeklyMenu implements MenuView {
         var it = e.getCurrentItem(); if (it == null) return;
         var m = org.bukkit.Material.matchMaterial(org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName()));
         if (m == null) return;
+        if (plugin.economy() == null) { p.sendMessage(plugin.prefixed(plugin.getConfig().getString("messages.no-economy"))); return; }
         int qty = e.isShiftClick() ? 16 : 1;
         plugin.shop().buy(p, m, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
     }


### PR DESCRIPTION
## Summary
- Avoid disabling the plugin when Vault isn't present
- Guard buy/sell commands and menus behind an economy check
- Notify users that buy/sell features require Vault

## Testing
- `mvn -q test` *(fails: The following artifacts could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a111f6bfb8832e9f2e59c0ef1b0fd1