### PR TITLE
Add guards against selling custom NBT items

### DIFF
--- a/src/main/java/com/yourorg/servershop/gui/SellMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/SellMenu.java
@@ -1,6 +1,7 @@
 package com.yourorg.servershop.gui;
 
 import com.yourorg.servershop.ServerShopPlugin;
+import com.yourorg.servershop.util.ItemUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -39,6 +40,7 @@ public final class SellMenu implements MenuView {
         for (ItemStack s : p.getInventory().getContents()) {
             if (s == null) continue; var m = s.getType();
             var e = plugin.catalog().get(m).orElse(null); if (e == null || !e.canSell()) continue;
+            if (!e.allowMeta() && ItemUtil.hasCustomMeta(s)) continue;
             map.put(m, map.getOrDefault(m, 0) + s.getAmount());
         }
         int i = 10;
@@ -57,6 +59,7 @@ public final class SellMenu implements MenuView {
             ItemStack s = p.getInventory().getItem(i);
             if (s == null) continue; var m = s.getType();
             var e = plugin.catalog().get(m).orElse(null); if (e == null || !e.canSell()) continue;
+            if (!e.allowMeta() && ItemUtil.hasCustomMeta(s)) continue;
             int qty = s.getAmount();
             double unit = plugin.shop().priceSell(m);
             double amount = unit * qty;
@@ -70,5 +73,13 @@ public final class SellMenu implements MenuView {
         refresh(p);
     }
 
-    private static int countOf(Player p, Material m){ int c=0; for (ItemStack s: p.getInventory().getContents()) if (s!=null && s.getType()==m) c+=s.getAmount(); return c; }
+    private int countOf(Player p, Material m){
+        int c = 0;
+        var e = plugin.catalog().get(m).orElse(null);
+        boolean allow = e != null && e.allowMeta();
+        for (ItemStack s: p.getInventory().getContents()) {
+            if (s != null && s.getType() == m && (allow || !ItemUtil.hasCustomMeta(s))) c += s.getAmount();
+        }
+        return c;
+    }
 }

--- a/src/main/java/com/yourorg/servershop/shop/Catalog.java
+++ b/src/main/java/com/yourorg/servershop/shop/Catalog.java
@@ -26,14 +26,17 @@ public final class Catalog {
         if (cats == null) return;
         for (String cat : cats.getKeys(false)) {
             ConfigurationSection sec = cats.getConfigurationSection(cat);
+            boolean catAllow = sec.getBoolean("allow-custom", false);
             List<Material> mats = new ArrayList<>();
             for (String key : sec.getKeys(false)) {
+                if ("allow-custom".equalsIgnoreCase(key)) continue;
                 Material m = Material.matchMaterial(key);
                 if (m == null) continue;
                 var isec = sec.getConfigurationSection(key);
                 double buy = isec.getDouble("buy", 0.0);
                 double sell = isec.getDouble("sell", 0.0);
-                items.put(m, new ItemEntry(m, buy, sell));
+                boolean allow = isec.getBoolean("allow-custom", catAllow);
+                items.put(m, new ItemEntry(m, buy, sell, allow));
                 mats.add(m);
                 catByMat.put(m, cat);
             }

--- a/src/main/java/com/yourorg/servershop/shop/ItemEntry.java
+++ b/src/main/java/com/yourorg/servershop/shop/ItemEntry.java
@@ -6,13 +6,15 @@ public final class ItemEntry {
     private final Material material;
     private final double buyPrice;
     private final double sellPrice;
+    private final boolean allowMeta;
 
-    public ItemEntry(Material material, double buyPrice, double sellPrice) {
-        this.material = material; this.buyPrice = buyPrice; this.sellPrice = sellPrice;
+    public ItemEntry(Material material, double buyPrice, double sellPrice, boolean allowMeta) {
+        this.material = material; this.buyPrice = buyPrice; this.sellPrice = sellPrice; this.allowMeta = allowMeta;
     }
     public Material material() { return material; }
     public double buyPrice() { return buyPrice; }
     public double sellPrice() { return sellPrice; }
     public boolean canBuy() { return buyPrice > 0; }
     public boolean canSell() { return sellPrice > 0; }
+    public boolean allowMeta() { return allowMeta; }
 }

--- a/src/main/java/com/yourorg/servershop/shop/ShopService.java
+++ b/src/main/java/com/yourorg/servershop/shop/ShopService.java
@@ -2,6 +2,7 @@ package com.yourorg.servershop.shop;
 
 import com.yourorg.servershop.ServerShopPlugin;
 import com.yourorg.servershop.logging.Transaction;
+import com.yourorg.servershop.util.ItemUtil;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -42,7 +43,7 @@ public final class ShopService {
         if (opt.isEmpty() || !opt.get().canSell()) return Optional.of(msg("not-sellable").replace("%material%", mat.name()));
         String cat = plugin.catalog().categoryOf(mat);
         if (!plugin.categorySettings().isEnabled(cat)) return Optional.of("Category disabled: "+cat);
-        int removed = removeFromInventory(p, mat, qty);
+        int removed = removeFromInventory(p, mat, qty, opt.get().allowMeta());
         if (removed <= 0) return Optional.of("You don't have that.");
         double unit = plugin.dynamic().sellPrice(mat, opt.get().sellPrice());
         double total = unit * removed;
@@ -63,11 +64,12 @@ public final class ShopService {
         return plugin.dynamic().sellPrice(mat, e.sellPrice());
     }
 
-    private int removeFromInventory(Player p, Material mat, int qty) {
+    private int removeFromInventory(Player p, Material mat, int qty, boolean allowMeta) {
         int remaining = qty;
         for (int i = 0; i < p.getInventory().getSize(); i++) {
             var stack = p.getInventory().getItem(i);
             if (stack == null || stack.getType() != mat) continue;
+            if (!allowMeta && ItemUtil.hasCustomMeta(stack)) continue;
             int take = Math.min(stack.getAmount(), remaining);
             stack.setAmount(stack.getAmount() - take);
             if (stack.getAmount() <= 0) p.getInventory().setItem(i, null);

--- a/src/main/java/com/yourorg/servershop/util/ItemUtil.java
+++ b/src/main/java/com/yourorg/servershop/util/ItemUtil.java
@@ -1,0 +1,18 @@
+package com.yourorg.servershop.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public final class ItemUtil {
+    private ItemUtil() {}
+
+    public static boolean hasCustomMeta(ItemStack stack) {
+        if (stack == null) return false;
+        ItemMeta meta = stack.getItemMeta();
+        if (meta == null) return false;
+        var factory = Bukkit.getItemFactory();
+        ItemMeta def = factory.getItemMeta(stack.getType());
+        return !factory.equals(meta, def);
+    }
+}


### PR DESCRIPTION
## Summary
- Track whether a shop entry allows custom metadata and parse optional `allow-custom` flags in `shop.yml`
- Block selling renamed or NBT-heavy items by default, unless the item entry permits metadata
- Ensure sell menus and sell-all respect metadata restrictions

## Testing
- `mvn -q -e -ntp test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a11201c304832eb733dfd1cd4e78a2