### PR TITLE
Add paginated shop menus with purchase confirmation

### DIFF
--- a/src/main/java/com/yourorg/servershop/gui/CategoryMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/CategoryMenu.java
@@ -6,37 +6,56 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public final class CategoryMenu implements MenuView {
+    private static final int PAGE_SIZE = 42;
     private final ServerShopPlugin plugin;
-    public CategoryMenu(ServerShopPlugin plugin) { this.plugin = plugin; }
+    private final int page;
+
+    public CategoryMenu(ServerShopPlugin plugin, int page) {
+        this.plugin = plugin;
+        this.page = Math.max(0, page);
+    }
+
+    public CategoryMenu(ServerShopPlugin plugin) { this(plugin, 0); }
 
     @Override public Inventory build() {
-        int rows = Math.max(1, plugin.getConfig().getInt("gui.rows.categories", 3));
-        Inventory inv = Bukkit.createInventory(null, rows*9, title());
+        Inventory inv = Bukkit.createInventory(null, 6*9, title());
+        List<String> cats = new ArrayList<>(plugin.catalog().categories().keySet());
+        int start = page * PAGE_SIZE;
+        int end = Math.min(cats.size(), start + PAGE_SIZE);
         int slot = 10;
-        for (String cat : plugin.catalog().categories().keySet()) {
+        for (int idx = start; idx < end; idx++) {
+            String cat = cats.get(idx);
             if (!plugin.categorySettings().isEnabled(cat)) continue;
             List<Material> mats = plugin.catalog().categories().get(cat);
             Material icon = (mats != null && !mats.isEmpty() && mats.get(0).isItem()) ? mats.get(0) : Material.CHEST;
             inv.setItem(slot, GuiUtil.item(icon, "&e"+cat, GuiUtil.lore("&7Click to view items")));
             slot += (slot % 9 == 7) ? 3 : 1;
         }
-        inv.setItem(rows*9-5, GuiUtil.item(Material.CLOCK, "&bWeekly Picks", GuiUtil.lore("&7Weekly discounts")));
-        inv.setItem(rows*9-4, GuiUtil.item(Material.GOLD_INGOT, "&aSell Items", GuiUtil.lore("&7Sell your loot")));
+        // navigation and special buttons
+        if (page > 0)
+            inv.setItem(6*9-9, GuiUtil.item(Material.ARROW, "&aPrevious Page", GuiUtil.lore("&7Go to page "+page)));
+        if (end < cats.size())
+            inv.setItem(6*9-1, GuiUtil.item(Material.ARROW, "&aNext Page", GuiUtil.lore("&7Go to page "+(page+2))));
+        inv.setItem(6*9-5, GuiUtil.item(Material.BOOK, "&bPage "+(page+1)+"/"+Math.max(1, (int)Math.ceil(cats.size()/(double)PAGE_SIZE)), java.util.List.of()));
+        inv.setItem(6*9-7, GuiUtil.item(Material.CLOCK, "&bWeekly Picks", GuiUtil.lore("&7Weekly discounts")));
+        inv.setItem(6*9-3, GuiUtil.item(Material.GOLD_INGOT, "&aSell Items", GuiUtil.lore("&7Sell your loot")));
         return inv;
     }
 
     @Override public void onClick(org.bukkit.event.inventory.InventoryClickEvent e) {
         if (!(e.getWhoClicked() instanceof Player p)) return;
-        var it = e.getCurrentItem(); if (it == null) return;
-        var name = it.getItemMeta() != null ? it.getItemMeta().getDisplayName() : "";
+        var it = e.getCurrentItem(); if (it == null || it.getItemMeta() == null) return;
+        String name = org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName());
+        if (name.equalsIgnoreCase("Previous Page")) { plugin.menus().openCategories(p, Math.max(0, page-1)); return; }
+        if (name.equalsIgnoreCase("Next Page")) { plugin.menus().openCategories(p, page+1); return; }
         if (name.contains("Weekly")) { plugin.menus().openWeekly(p); return; }
         if (name.contains("Sell")) { plugin.menus().openSell(p); return; }
-        String clean = org.bukkit.ChatColor.stripColor(name);
-        if (!plugin.categorySettings().isEnabled(clean)) { p.sendMessage(plugin.prefixed("Category disabled.")); return; }
-        plugin.menus().openItems(p, clean);
+        if (!plugin.categorySettings().isEnabled(name)) { p.sendMessage(plugin.prefixed("Category disabled.")); return; }
+        plugin.menus().openItems(p, name, 0);
     }
 
     @Override public String title() { return plugin.getConfig().getString("gui.titles.categories", "Server Shop"); }

--- a/src/main/java/com/yourorg/servershop/gui/ConfirmMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/ConfirmMenu.java
@@ -1,0 +1,48 @@
+package com.yourorg.servershop.gui;
+
+import com.yourorg.servershop.ServerShopPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+
+import java.util.function.Consumer;
+
+public final class ConfirmMenu implements MenuView {
+    private final ServerShopPlugin plugin;
+    private final Material material;
+    private final Consumer<Player> back;
+
+    public ConfirmMenu(ServerShopPlugin plugin, Material material, Consumer<Player> back) {
+        this.plugin = plugin;
+        this.material = material;
+        this.back = back;
+    }
+
+    @Override public Inventory build() {
+        Inventory inv = Bukkit.createInventory(null, 3*9, title());
+        double unit = plugin.shop().priceBuy(material);
+        inv.setItem(13, GuiUtil.item(material.isItem()?material:Material.BOOK, "&e"+material.name(), GuiUtil.lore(
+                "&7Price each: &a$"+String.format("%.2f", unit))));
+        inv.setItem(11, GuiUtil.item(Material.EMERALD, "&aBuy 1", GuiUtil.lore("&7Cost: &a$"+String.format("%.2f", unit))));
+        inv.setItem(15, GuiUtil.item(Material.EMERALD_BLOCK, "&aBuy 16", GuiUtil.lore("&7Cost: &a$"+String.format("%.2f", unit*16))));
+        inv.setItem(18, GuiUtil.item(Material.ARROW, "&cBack", GuiUtil.lore("&7Return")));
+        return inv;
+    }
+
+    @Override public void onClick(InventoryClickEvent e) {
+        if (!(e.getWhoClicked() instanceof Player p)) return;
+        var it = e.getCurrentItem(); if (it == null || it.getItemMeta() == null) return;
+        String name = org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName());
+        if (name.equalsIgnoreCase("Back")) { back.accept(p); return; }
+        int qty = name.contains("16") ? 16 : 1;
+        plugin.shop().buy(p, material, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
+        back.accept(p);
+    }
+
+    @Override public String title() {
+        return plugin.getConfig().getString("gui.titles.confirm", "Confirm Purchase");
+    }
+}
+

--- a/src/main/java/com/yourorg/servershop/gui/ItemsMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/ItemsMenu.java
@@ -10,43 +10,63 @@ import org.bukkit.inventory.Inventory;
 import java.util.List;
 
 public final class ItemsMenu implements MenuView {
-    private final ServerShopPlugin plugin; private final String category;
-    public ItemsMenu(ServerShopPlugin plugin, String category) { this.plugin = plugin; this.category = category; }
+    private static final int PAGE_SIZE = 42;
+    private final ServerShopPlugin plugin;
+    private final String category;
+    private final int page;
+
+    public ItemsMenu(ServerShopPlugin plugin, String category, int page) {
+        this.plugin = plugin;
+        this.category = category;
+        this.page = Math.max(0, page);
+    }
+
+    public ItemsMenu(ServerShopPlugin plugin, String category) { this(plugin, category, 0); }
 
     @Override public Inventory build() {
-        int rows = Math.max(1, plugin.getConfig().getInt("gui.rows.items", 6));
-        Inventory inv = Bukkit.createInventory(null, rows*9, title());
+        Inventory inv = Bukkit.createInventory(null, 6*9, title());
         var mats = plugin.catalog().categories().getOrDefault(category, List.of());
+        int start = page * PAGE_SIZE;
+        int end = Math.min(mats.size(), start + PAGE_SIZE);
         int i = 10;
-        for (var m : mats) {
+        for (int idx = start; idx < end; idx++) {
+            Material m = mats.get(idx);
             double buy = plugin.shop().priceBuy(m);
             double sell = plugin.shop().priceSell(m);
-            inv.setItem(i, GuiUtil.item(m.isItem() ? m : Material.BOOK, "&e"+m.name(), GuiUtil.lore(
+            inv.setItem(i, GuiUtil.item(m.isItem()?m:Material.BOOK, "&e"+m.name(), GuiUtil.lore(
                     "&7Buy: &a$"+String.format("%.2f", buy),
                     "&7Sell: &6$"+(sell>0?String.format("%.2f", sell):"-"),
-                    "&8Left-click: buy 1  |  Shift-left: buy 16",
+                    "&8Left-click: buy",
                     "&8Right-click: show price"
             )));
             i += (i % 9 == 7) ? 3 : 1;
         }
+        if (page > 0)
+            inv.setItem(6*9-9, GuiUtil.item(Material.ARROW, "&aPrevious Page", GuiUtil.lore("&7Go to page "+page)));
+        if (end < mats.size())
+            inv.setItem(6*9-1, GuiUtil.item(Material.ARROW, "&aNext Page", GuiUtil.lore("&7Go to page "+(page+2))));
+        inv.setItem(6*9-5, GuiUtil.item(Material.BOOK, "&bPage "+(page+1)+"/"+Math.max(1,(int)Math.ceil(mats.size()/(double)PAGE_SIZE)), java.util.List.of()));
         return inv;
     }
 
     @Override public void onClick(InventoryClickEvent e) {
         if (!(e.getWhoClicked() instanceof Player p)) return;
-        var it = e.getCurrentItem(); if (it == null) return;
-        var mat = it.getType();
-        if (mat == null || mat == Material.AIR) return;
-        var m = org.bukkit.Material.matchMaterial(org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName()));
+        var it = e.getCurrentItem(); if (it == null || it.getItemMeta() == null) return;
+        String name = org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName());
+        if (name.equalsIgnoreCase("Previous Page")) { plugin.menus().openItems(p, category, Math.max(0, page-1)); return; }
+        if (name.equalsIgnoreCase("Next Page")) { plugin.menus().openItems(p, category, page+1); return; }
+        Material m = org.bukkit.Material.matchMaterial(name);
         if (m == null) return;
         if (e.isRightClick()) {
             double buy = plugin.shop().priceBuy(m);
             p.sendMessage(plugin.prefixed(m.name()+": $"+String.format("%.2f", buy)));
             return;
         }
-        int qty = e.isShiftClick() ? 16 : 1;
-        plugin.shop().buy(p, m, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
+        plugin.menus().openConfirm(p, m, pl -> plugin.menus().openItems(pl, category, page));
     }
 
-    @Override public String title() { return plugin.getConfig().getString("gui.titles.items", "%category%").replace("%category%", category); }
+    @Override public String title() {
+        return plugin.getConfig().getString("gui.titles.items", "%category%").replace("%category%", category);
+    }
 }
+

--- a/src/main/java/com/yourorg/servershop/gui/MenuManager.java
+++ b/src/main/java/com/yourorg/servershop/gui/MenuManager.java
@@ -1,6 +1,7 @@
 package com.yourorg.servershop.gui;
 
 import com.yourorg.servershop.ServerShopPlugin;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -8,18 +9,23 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
 
+import java.util.function.Consumer;
+
 public final class MenuManager implements Listener {
     private final ServerShopPlugin plugin;
     private final java.util.Map<java.util.UUID, MenuView> open = new java.util.HashMap<>();
 
     public MenuManager(ServerShopPlugin plugin) { this.plugin = plugin; }
 
-    public void openCategories(Player p) { open(p, new CategoryMenu(plugin)); }
-    public void openItems(Player p, String category) { open(p, new ItemsMenu(plugin, category)); }
+    public void openCategories(Player p) { openCategories(p, 0); }
+    public void openCategories(Player p, int page) { open(p, new CategoryMenu(plugin, page)); }
+    public void openItems(Player p, String category) { openItems(p, category, 0); }
+    public void openItems(Player p, String category, int page) { open(p, new ItemsMenu(plugin, category, page)); }
     public void openWeekly(Player p) { if (p!=null) open(p, new WeeklyMenu(plugin)); }
     public void openSell(Player p) { open(p, new SellMenu(plugin)); }
     public void openSearch(Player p, String query, java.util.List<org.bukkit.Material> results) { open(p, new SearchMenu(plugin, query, results, 0)); }
     public void openSearch(Player p, String query, java.util.List<org.bukkit.Material> results, int page) { open(p, new SearchMenu(plugin, query, results, page)); }
+    public void openConfirm(Player p, Material m, Consumer<Player> back) { open(p, new ConfirmMenu(plugin, m, back)); }
 
     private void open(Player p, MenuView view) {
         Inventory inv = view.build();

--- a/src/main/java/com/yourorg/servershop/gui/SearchMenu.java
+++ b/src/main/java/com/yourorg/servershop/gui/SearchMenu.java
@@ -33,7 +33,7 @@ public final class SearchMenu implements MenuView {
             inv.setItem(i, GuiUtil.item(m.isItem()?m:Material.PAPER, "&e"+m.name(), GuiUtil.lore(
                     "&7Buy: &a$"+String.format("%.2f", buy),
                     "&7Sell: &6$"+(sell>0?String.format("%.2f", sell):"-"),
-                    "&8Left-click: buy 1  |  Shift-left: buy 16",
+                    "&8Left-click: buy",
                     "&8Right-click: show price")));
             i += (i % 9 == 7) ? 3 : 1;
         }
@@ -52,8 +52,7 @@ public final class SearchMenu implements MenuView {
         var m = org.bukkit.Material.matchMaterial(org.bukkit.ChatColor.stripColor(it.getItemMeta().getDisplayName()));
         if (m == null) return;
         if (e.isRightClick()) { double buy = plugin.shop().priceBuy(m); p.sendMessage(plugin.prefixed(m.name()+": $"+String.format("%.2f", buy))); return; }
-        int qty = e.isShiftClick() ? 16 : 1;
-        plugin.shop().buy(p, m, qty).ifPresent(err -> p.sendMessage(plugin.prefixed(err)));
+        plugin.menus().openConfirm(p, m, pl -> plugin.menus().openSearch(pl, query, results, page));
     }
 
     @Override public String title() { return plugin.getConfig().getString("gui.titles.items", "%category%").replace("%category%", "Search: "+query+" ("+(page+1)+")"); }


### PR DESCRIPTION
## Summary
- Implement pagination for category and item inventories with next/previous controls and page indicators
- Introduce a confirmation menu to finalize item purchases
- Integrate confirmation step into search results view and refactor menu manager for new navigation

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1121305e0832e978e50df2a64acc6