### PR TITLE
Add tax breakdown details to transactions

### DIFF
--- a/src/main/java/com/yourorg/servershop/shop/ShopService.java
+++ b/src/main/java/com/yourorg/servershop/shop/ShopService.java
@@ -20,7 +20,10 @@ public final class ShopService {
         String cat = plugin.catalog().categoryOf(mat);
         if (!plugin.categorySettings().isEnabled(cat)) return Optional.of("Category disabled: "+cat);
         double unit = plugin.dynamic().buyPrice(mat, opt.get().buyPrice());
-        double total = unit * qty;
+        double subtotal = unit * qty;
+        double taxRate = plugin.getConfig().getDouble("taxRate", 0.0);
+        double tax = subtotal * taxRate;
+        double total = subtotal + tax;
         var econ = plugin.economy();
         if (econ.getBalance(p) + 1e-9 < total) {
             double need = Math.max(0, total - econ.getBalance(p));
@@ -34,6 +37,9 @@ public final class ShopService {
         plugin.dynamic().adjustOnBuy(mat, qty);
         plugin.logger().logAsync(new Transaction(Instant.now(), p.getName(), Transaction.Type.BUY, mat, qty, total));
         p.sendMessage(plugin.prefixed(msg("purchased").replace("%qty%", String.valueOf(qty)).replace("%material%", mat.name()).replace("%price%", fmt(total))));
+        String breakdown = org.bukkit.ChatColor.translateAlternateColorCodes('&',
+                "&6$"+fmt(unit)+" &7× &e"+qty+" &7→ &c$"+fmt(tax)+" &7→ &a$"+fmt(total));
+        p.sendMessage(plugin.prefixed(breakdown));
         return Optional.empty();
     }
 
@@ -45,11 +51,17 @@ public final class ShopService {
         int removed = removeFromInventory(p, mat, qty);
         if (removed <= 0) return Optional.of("You don't have that.");
         double unit = plugin.dynamic().sellPrice(mat, opt.get().sellPrice());
-        double total = unit * removed;
+        double subtotal = unit * removed;
+        double taxRate = plugin.getConfig().getDouble("taxRate", 0.0);
+        double tax = subtotal * taxRate;
+        double total = subtotal - tax;
         plugin.economy().depositPlayer(p, total);
         plugin.dynamic().adjustOnSell(mat, removed);
         plugin.logger().logAsync(new Transaction(Instant.now(), p.getName(), Transaction.Type.SELL, mat, removed, total));
         p.sendMessage(plugin.prefixed(msg("sold").replace("%qty%", String.valueOf(removed)).replace("%material%", mat.name()).replace("%price%", fmt(total))));
+        String breakdown = org.bukkit.ChatColor.translateAlternateColorCodes('&',
+                "&6$"+fmt(unit)+" &7× &e"+removed+" &7→ &c$"+fmt(tax)+" &7→ &a$"+fmt(total));
+        p.sendMessage(plugin.prefixed(breakdown));
         return Optional.empty();
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,6 @@
 messages:
   prefix: '&6[Shop] &7'
+taxRate: 0.0
 weekly:
   count: 6
   discount: 0.80


### PR DESCRIPTION
## Summary
- add configurable tax rate
- show "unit × amount → tax → total" breakdown for buy and sell
- include tax calculations in bulk sell

## Testing
- `mvn -q -e test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a112160bf4832e9c0e05d4f6013799