### PR TITLE
Add opt-in bStats metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
       <artifactId>mysql-connector-j</artifactId>
       <version>8.4.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.bstats</groupId>
+      <artifactId>bstats-bukkit</artifactId>
+      <version>3.0.2</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/yourorg/servershop/ServerShopPlugin.java
+++ b/src/main/java/com/yourorg/servershop/ServerShopPlugin.java
@@ -7,6 +7,7 @@ import com.yourorg.servershop.shop.*;
 import com.yourorg.servershop.weekly.*;
 import com.yourorg.servershop.dynamic.*;
 import com.yourorg.servershop.config.*;
+import com.yourorg.servershop.metrics.*;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -22,6 +23,7 @@ public final class ServerShopPlugin extends JavaPlugin {
     private ShopService shopService;
     private DynamicPricingManager dynamic;
     private CategorySettings categorySettings;
+    private MetricsManager metrics;
 
     @Override public void onEnable() {
         saveDefaultConfig();
@@ -35,6 +37,7 @@ public final class ServerShopPlugin extends JavaPlugin {
         this.categorySettings = new CategorySettings(this);
         this.catalog = new Catalog(this); catalog.reload();
         this.weekly = new WeeklyShopManager(this);
+        this.metrics = new MetricsManager(this);
         this.logger = new LoggerManager(this);
         this.dynamic = new DynamicPricingManager(this);
         this.shopService = new ShopService(this);
@@ -74,6 +77,7 @@ public final class ServerShopPlugin extends JavaPlugin {
     public Economy economy() { return economy; }
     public Catalog catalog() { return catalog; }
     public LoggerManager logger() { return logger; }
+    public MetricsManager metrics() { return metrics; }
     public WeeklyShopManager weekly() { return weekly; }
     public MenuManager menus() { return menus; }
     public ShopService shop() { return shopService; }

--- a/src/main/java/com/yourorg/servershop/logging/LoggerManager.java
+++ b/src/main/java/com/yourorg/servershop/logging/LoggerManager.java
@@ -43,6 +43,7 @@ public final class LoggerManager {
     }
 
     public void logAsync(Transaction tx) {
+        plugin.metrics().track(tx);
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             try { storage.append(tx); } catch (Exception e) { plugin.getLogger().warning("Failed to log: " + e.getMessage()); }
         });

--- a/src/main/java/com/yourorg/servershop/metrics/MetricsManager.java
+++ b/src/main/java/com/yourorg/servershop/metrics/MetricsManager.java
@@ -1,0 +1,67 @@
+package com.yourorg.servershop.metrics;
+
+import com.yourorg.servershop.ServerShopPlugin;
+import com.yourorg.servershop.logging.Transaction;
+import org.bstats.bukkit.Metrics;
+import org.bstats.charts.AdvancedPie;
+import org.bstats.charts.MultiLineChart;
+import org.bstats.charts.SingleLineChart;
+import org.bukkit.Material;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class MetricsManager {
+    private static final int BSTATS_ID = 21357; // bStats plugin ID
+    private final boolean enabled;
+    private final Stats stats = new Stats();
+
+    public MetricsManager(ServerShopPlugin plugin) {
+        this.enabled = plugin.getConfig().getBoolean("metrics.enabled", false);
+        if (!enabled) return;
+        Metrics metrics = new Metrics(plugin, BSTATS_ID);
+        metrics.addCustomChart(new MultiLineChart("transactions", () -> stats.buySellMap()));
+        metrics.addCustomChart(new AdvancedPie("top_items", () -> stats.topItems()));
+        metrics.addCustomChart(new SingleLineChart("average_transaction", () -> stats.averageAmount()));
+    }
+
+    public void track(Transaction tx) {
+        if (!enabled) return;
+        stats.record(tx);
+    }
+
+    private static class Stats {
+        private int buys = 0;
+        private int sells = 0;
+        private double totalAmount = 0;
+        private final Map<Material, Integer> itemCounts = new HashMap<>();
+
+        synchronized void record(Transaction tx) {
+            if (tx.type == Transaction.Type.BUY) buys++; else sells++;
+            totalAmount += tx.amount;
+            itemCounts.merge(tx.material, tx.quantity, Integer::sum);
+        }
+
+        synchronized Map<String, Integer> buySellMap() {
+            Map<String, Integer> map = new HashMap<>();
+            map.put("buys", buys);
+            map.put("sells", sells);
+            return map;
+        }
+
+        synchronized Map<String, Integer> topItems() {
+            return itemCounts.entrySet().stream()
+                    .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+                    .limit(5)
+                    .collect(Collectors.toMap(e -> e.getKey().name(), Map.Entry::getValue, (a, b) -> a, LinkedHashMap::new));
+        }
+
+        synchronized int averageAmount() {
+            int total = buys + sells;
+            if (total == 0) return 0;
+            return (int) Math.round(totalAmount / total);
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,6 +8,8 @@ priceModel:
   minFactor: 0.5
   maxFactor: 1.5
   sellStep: 0.01
+metrics:
+  enabled: false
 logging:
   storage: YAML  # YAML or MYSQL
   maxEntries: 1000


### PR DESCRIPTION
## Summary
- Integrate bStats metrics with optional toggle
- Track buy/sell counts, top traded items and average transaction value
- Update config and build to support metrics

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a112375c3c832eb113c1b07c67b4ca